### PR TITLE
Fix: make full games completable (stalemate detection + king multi-captures)

### DIFF
--- a/examples/InternationalDraughts.ts
+++ b/examples/InternationalDraughts.ts
@@ -1,74 +1,31 @@
-import { CustomRulesBase } from '../src/rules/CustomRulesBase';
+import { StandardRules } from '../src/rules/StandardRules';
 import { Board } from '../src/core/Board';
-import { Move } from '../src/core/Move';
 import { Position } from '../src/core/Position';
 import { Player } from '../src/types';
 import { RegularPiece } from '../src/pieces/RegularPiece';
 
 /**
- * International Draughts (10x10) rules implementation.
- * - Played on 10x10 board
- * - Kings can fly (move multiple squares)
- * - Must capture maximum possible pieces
- * - Different piece placement
+ * International Draughts (10x10).
+ *
+ * The engine's core already provides the rules that distinguish International
+ * Draughts from a naive game: flying kings (see {@link KingPiece}), captures in
+ * any diagonal direction for men, multi-jump sequences, and the mandatory
+ * maximum-capture rule (see {@link StandardRules.getMandatoryMoves}). So this
+ * variant only needs the larger board and its four-rows-per-side setup; all
+ * move generation and validation are inherited and stay consistent.
  */
-export class InternationalDraughtsRules extends CustomRulesBase {
+export class InternationalDraughtsRules extends StandardRules {
   constructor(boardSize: number = 10) {
-    super(boardSize); // Default to 10x10 for International Draughts
+    super(boardSize);
   }
 
   /**
-   * Enhanced move validation for flying kings.
-   */
-  override validateMove(board: Board, move: Move): boolean {
-    const piece = board.getPiece(move.from);
-    if (!piece) return false;
-
-    // For kings, allow flying moves
-    if (piece.isKing()) {
-      return this.validateFlyingKingMove(board, move);
-    }
-
-    // Regular pieces follow standard rules
-    return super.validateMove(board, move);
-  }
-
-  /**
-   * Enhanced move generation for flying kings.
-   */
-  override getPossibleMoves(board: Board, position: Position): Move[] {
-    const piece = board.getPiece(position);
-    if (!piece) return [];
-
-    if (piece.isKing()) {
-      return this.getFlyingKingMoves(board, position);
-    }
-
-    return super.getPossibleMoves(board, position);
-  }
-
-  /**
-   * Must capture maximum possible pieces rule.
-   */
-  override getMandatoryMoves(board: Board, player: Player): Move[] {
-    const allCaptures = this.getAllCaptureMoves(board, player);
-    
-    if (allCaptures.length === 0) return [];
-
-    // Find maximum capture count
-    const maxCaptures = Math.max(...allCaptures.map(move => move.getCaptureCount()));
-    
-    // Return only moves that capture the maximum
-    return allCaptures.filter(move => move.getCaptureCount() === maxCaptures);
-  }
-
-  /**
-   * International draughts initial setup (4 rows each).
+   * International setup: four rows of pieces per side on a 10x10 board.
    */
   override getInitialBoard(): Board {
     let board = new Board(10);
 
-    // Place black pieces (top 4 rows)
+    // Black pieces fill the top four rows (dark squares only).
     for (let row = 0; row < 4; row++) {
       for (let col = 0; col < 10; col++) {
         const pos = new Position(row, col);
@@ -78,7 +35,7 @@ export class InternationalDraughtsRules extends CustomRulesBase {
       }
     }
 
-    // Place red pieces (bottom 4 rows)
+    // Red pieces fill the bottom four rows.
     for (let row = 6; row < 10; row++) {
       for (let col = 0; col < 10; col++) {
         const pos = new Position(row, col);
@@ -89,141 +46,5 @@ export class InternationalDraughtsRules extends CustomRulesBase {
     }
 
     return board;
-  }
-
-  /**
-   * Validates flying king moves.
-   */
-  private validateFlyingKingMove(board: Board, move: Move): boolean {
-    if (!move.isDiagonal()) return false;
-
-    const betweenPositions = move.from.getPositionsBetween(move.to);
-    
-    if (move.isCapture()) {
-      // For captures, exactly one opponent should be captured
-      const occupiedPositions = betweenPositions.filter(pos => !board.isEmpty(pos));
-      
-      if (occupiedPositions.length !== 1) return false;
-      
-      const capturedPos = occupiedPositions[0]!;
-      const capturedPiece = board.getPiece(capturedPos);
-      
-      const movingPiece = board.getPiece(move.from);
-      return capturedPiece !== null && 
-             movingPiece !== null &&
-             capturedPiece.player !== movingPiece.player && 
-             move.captures.some(cap => cap.equals(capturedPos));
-    } else {
-      // For regular moves, path must be clear
-      return betweenPositions.every(pos => board.isEmpty(pos));
-    }
-  }
-
-  /**
-   * Gets all possible flying king moves.
-   */
-  private getFlyingKingMoves(board: Board, position: Position): Move[] {
-    const moves: Move[] = [];
-    const directions = ['NW', 'NE', 'SW', 'SE'] as const;
-
-    for (const direction of directions) {
-      // Regular moves in this direction
-      const regularMoves = this.getRegularMovesInDirection(board, position, direction);
-      moves.push(...regularMoves);
-
-      // Capture moves in this direction
-      const captureMoves = this.getCaptureMovesInDirection(board, position, direction);
-      moves.push(...captureMoves);
-    }
-
-    return moves;
-  }
-
-  /**
-   * Gets regular moves in a specific direction for flying kings.
-   */
-  private getRegularMovesInDirection(
-    board: Board, 
-    position: Position, 
-    direction: 'NW' | 'NE' | 'SW' | 'SE'
-  ): Move[] {
-    const moves: Move[] = [];
-    let currentPos = position;
-
-    while (true) {
-      const nextPos = this.getNextPositionInDirection(currentPos, direction);
-      if (!nextPos || !board.isValidPosition(nextPos)) break;
-
-      if (!board.isEmpty(nextPos)) break;
-      
-      moves.push(new Move(position, nextPos));
-      currentPos = nextPos;
-    }
-
-    return moves;
-  }
-
-  /**
-   * Gets capture moves in a specific direction for flying kings.
-   */
-  private getCaptureMovesInDirection(
-    board: Board,
-    position: Position,
-    direction: 'NW' | 'NE' | 'SW' | 'SE'
-  ): Move[] {
-    const moves: Move[] = [];
-    let currentPos = position;
-    const piece = board.getPiece(position);
-    if (!piece) return moves;
-
-    // Look for opponent pieces to capture
-    while (true) {
-      const nextPos = this.getNextPositionInDirection(currentPos, direction);
-      if (!nextPos || !board.isValidPosition(nextPos)) break;
-
-      const nextPiece = board.getPiece(nextPos);
-      
-      // Hit our own piece - stop
-      if (nextPiece && nextPiece.player === piece.player) break;
-      
-      // Found opponent piece
-      if (nextPiece && nextPiece.player !== piece.player) {
-        // Look for landing positions after the captured piece
-        let landingPos = nextPos;
-        while (true) {
-          const nextLandingPos = this.getNextPositionInDirection(landingPos, direction);
-          if (!nextLandingPos || !board.isValidPosition(nextLandingPos)) break;
-          if (!board.isEmpty(nextLandingPos)) break;
-          
-          moves.push(new Move(position, nextLandingPos, [nextPos]));
-          landingPos = nextLandingPos;
-        }
-        break; // Only one capture per direction in this simple implementation
-      }
-      
-      currentPos = nextPos;
-    }
-
-    return moves;
-  }
-
-  /**
-   * Helper to get next position in a direction.
-   */
-  private getNextPositionInDirection(
-    pos: Position, 
-    direction: 'NW' | 'NE' | 'SW' | 'SE'
-  ): Position | null {
-    let { row, col } = pos;
-
-    switch (direction) {
-    case 'NW': row--; col--; break;
-    case 'NE': row--; col++; break;
-    case 'SW': row++; col--; break;
-    case 'SE': row++; col++; break;
-    }
-
-    const newPos = new Position(row, col);
-    return newPos.isValid(10) ? newPos : null;
   }
 }

--- a/src/core/Game.ts
+++ b/src/core/Game.ts
@@ -69,9 +69,13 @@ export class Game {
 
   /**
    * Checks if the game is over.
+   *
+   * Determined from the actual player to move (which the controller tracks),
+   * not from the rule engine's board-only `isGameOver` — that method has to
+   * guess whose turn it is from the board and is unreliable mid-game.
    */
   isGameOver(): boolean {
-    return this.gameOver || this.ruleEngine.isGameOver(this.board);
+    return this.gameOver || this.computeGameOver();
   }
 
   /**
@@ -79,7 +83,33 @@ export class Game {
    */
   getWinner(): Player | null {
     if (!this.isGameOver()) return null;
-    return this.winner || this.ruleEngine.getWinner(this.board);
+    return this.winner ?? this.computeWinner();
+  }
+
+  /**
+   * A game is over when either side has been eliminated or the player to move
+   * has no legal move.
+   */
+  private computeGameOver(): boolean {
+    if (this.board.getPieceCount(Player.RED) === 0 || this.board.getPieceCount(Player.BLACK) === 0) {
+      return true;
+    }
+    return this.ruleEngine.getAllPossibleMoves(this.board, this.currentPlayer).length === 0;
+  }
+
+  /**
+   * Determines the winner of a finished game. A player with no pieces — or the
+   * player to move when they have no legal move — loses.
+   */
+  private computeWinner(): Player | null {
+    const red = this.board.getPieceCount(Player.RED);
+    const black = this.board.getPieceCount(Player.BLACK);
+    if (black === 0) return Player.RED;
+    if (red === 0) return Player.BLACK;
+    if (this.ruleEngine.getAllPossibleMoves(this.board, this.currentPlayer).length === 0) {
+      return this.currentPlayer === Player.RED ? Player.BLACK : Player.RED;
+    }
+    return null;
   }
 
   /**
@@ -357,9 +387,9 @@ export class Game {
    * Checks if the game has ended.
    */
   private checkGameEnd(): void {
-    if (this.ruleEngine.isGameOver(this.board)) {
+    if (this.computeGameOver()) {
       this.gameOver = true;
-      this.winner = this.ruleEngine.getWinner(this.board);
+      this.winner = this.computeWinner();
     }
   }
 

--- a/src/pieces/KingPiece.ts
+++ b/src/pieces/KingPiece.ts
@@ -2,7 +2,7 @@ import { Piece } from './Piece';
 import { Position } from '../core/Position';
 import { Board } from '../core/Board';
 import { Move } from '../core/Move';
-import { Player, Direction } from '../types';
+import { Player, Direction, MoveStep } from '../types';
 
 /**
  * King piece that can move in all diagonal directions.
@@ -58,22 +58,15 @@ export class KingPiece extends Piece {
   }
 
   /**
-   * Gets possible capture moves for a king.
+   * Gets possible capture moves for a king, including multi-jump sequences.
+   * Each returned move carries explicit per-jump `steps` so that turning
+   * sequences (whose start and end are not on a single diagonal) are
+   * represented and validated correctly.
    */
   getCaptureMoves(position: Position, board: Board): Move[] {
-    const captures: Move[] = [];
-    
-    for (const direction of this.getMoveDirections()) {
-      const capturesInDirection = this.getCapturesInDirection(
-        position,
-        direction,
-        board,
-        []
-      );
-      captures.push(...capturesInDirection);
-    }
-    
-    return captures;
+    const sequences: Move[] = [];
+    this.collectCaptures(position, position, board, [], [], sequences);
+    return sequences;
   }
 
   /**
@@ -145,73 +138,69 @@ export class KingPiece extends Piece {
   }
 
   /**
-   * Finds all capture moves in a given direction.
+   * Recursively builds flying-king capture sequences. The board is never
+   * mutated: pieces captured earlier in the sequence remain on the board and
+   * therefore act as blockers (you may not jump the same piece twice, and a
+   * captured piece blocks the king's path until the turn ends).
+   *
+   * @param start    The king's original square (the move's `from`).
+   * @param current  The square the king is jumping from at this step.
+   * @param captured Pieces captured so far in this sequence.
+   * @param steps    The jump steps taken so far.
+   * @param out      Accumulator for every valid (partial or full) sequence.
    */
-  private getCapturesInDirection(
-    from: Position,
-    direction: Direction,
+  private collectCaptures(
+    start: Position,
+    current: Position,
     board: Board,
-    alreadyCaptured: Position[]
-  ): Move[] {
-    const captures: Move[] = [];
-    const positions = this.getPositionsInDirection(from, direction, board.size - 1, board.size);
-    
-    let foundOpponent = false;
-    let opponentPos: Position | null = null;
-    
-    for (const pos of positions) {
-      if (!board.isValidPosition(pos)) break;
-      
-      const piece = board.getPiece(pos);
-      
-      // Hit our own piece - can't continue
-      if (piece && piece.belongsTo(this.player)) break;
-      
-      // Found an opponent
-      if (piece && !foundOpponent && !this.isAlreadyCaptured(pos, alreadyCaptured)) {
-        foundOpponent = true;
-        opponentPos = pos;
-        continue;
-      }
-      
-      // Found a second piece - can't jump over two pieces
-      if (piece && foundOpponent) break;
-      
-      // Found empty square after opponent - valid landing position
-      if (!piece && foundOpponent && opponentPos) {
-        const newCapture = new Move(from, pos, [opponentPos]);
-        captures.push(newCapture);
-        
-        // Check for additional captures from this position
-        const newAlreadyCaptured = [...alreadyCaptured, opponentPos];
-        for (const nextDirection of this.getMoveDirections()) {
-          const additionalCaptures = this.getCapturesInDirection(
-            pos,
-            nextDirection,
-            board,
-            newAlreadyCaptured
-          );
-          
-          // Combine captures into multi-capture moves
-          for (const additional of additionalCaptures) {
-            captures.push(new Move(
-              from,
-              additional.to,
-              [...newCapture.captures, ...additional.captures],
-              false
-            ));
-          }
-        }
+    captured: Position[],
+    steps: MoveStep[],
+    out: Move[]
+  ): void {
+    for (const direction of this.getMoveDirections()) {
+      const jump = this.findJumpInDirection(current, direction, board, captured);
+      if (!jump) continue;
+
+      for (const landing of jump.landings) {
+        const step: MoveStep = { from: current, to: landing, captured: jump.opponent };
+        const nextSteps = [...steps, step];
+        const nextCaptured = [...captured, jump.opponent];
+
+        out.push(new Move(start, landing, nextCaptured, false, nextSteps));
+        this.collectCaptures(start, landing, board, nextCaptured, nextSteps, out);
       }
     }
-    
-    return captures;
   }
 
   /**
-   * Checks if a position is already captured in the current sequence.
+   * Looks along one diagonal for the first jumpable opponent and the empty
+   * landing squares beyond it. Returns null if no capture is possible that way.
    */
-  private isAlreadyCaptured(position: Position, captured: Position[]): boolean {
-    return captured.some(pos => pos.equals(position));
+  private findJumpInDirection(
+    from: Position,
+    direction: Direction,
+    board: Board,
+    captured: Position[]
+  ): { opponent: Position; landings: Position[] } | null {
+    // Glide over empty squares to the first occupied one.
+    let scan = this.getNextPosition(from, direction, board.size);
+    while (scan && board.isEmpty(scan)) {
+      scan = this.getNextPosition(scan, direction, board.size);
+    }
+    if (!scan) return null;
+
+    const blocker = board.getPiece(scan);
+    // Can only jump a fresh opponent piece.
+    if (!blocker || blocker.belongsTo(this.player)) return null;
+    if (captured.some(c => c.equals(scan))) return null;
+
+    const opponent = scan;
+    const landings: Position[] = [];
+    let landing = this.getNextPosition(opponent, direction, board.size);
+    while (landing && board.isEmpty(landing)) {
+      landings.push(landing);
+      landing = this.getNextPosition(landing, direction, board.size);
+    }
+    return landings.length > 0 ? { opponent, landings } : null;
   }
 }

--- a/src/strategies/MultiStepMoveValidator.ts
+++ b/src/strategies/MultiStepMoveValidator.ts
@@ -50,9 +50,12 @@ export class MultiStepMoveValidator extends BaseMoveValidator {
       }
 
       if (step.captured) {
-        // Capture steps jump exactly two squares over a single opponent.
-        if (step.from.diagonalDistanceTo(step.to) !== 2) {
-          throw new InvalidMoveError(move, 'Capture step must span two squares');
+        // A capture step jumps one opponent that lies on the diagonal between
+        // the endpoints, with the rest of the path clear. This covers both a
+        // regular piece's two-square jump and a king's longer flying jump.
+        const between = step.from.getPositionsBetween(step.to);
+        if (!between.some(pos => pos.equals(step.captured!))) {
+          throw new InvalidMoveError(move, 'Captured piece must lie between step endpoints');
         }
 
         const capturedPiece = tempBoard.getPiece(step.captured);
@@ -60,9 +63,10 @@ export class MultiStepMoveValidator extends BaseMoveValidator {
           throw new InvalidMoveError(move, 'Capture step must jump an opponent piece');
         }
 
-        const middlePositions = step.from.getPositionsBetween(step.to);
-        if (middlePositions.length !== 1 || !middlePositions[0]!.equals(step.captured)) {
-          throw new InvalidMoveError(move, 'Captured piece must lie between step endpoints');
+        for (const pos of between) {
+          if (!pos.equals(step.captured) && !tempBoard.isEmpty(pos)) {
+            throw new InvalidMoveError(move, 'Capture path is blocked');
+          }
         }
 
         tempBoard = tempBoard.removePiece(step.captured);

--- a/tests/integration/FullPlaythrough.test.ts
+++ b/tests/integration/FullPlaythrough.test.ts
@@ -1,0 +1,105 @@
+import { Game } from '../../src/core/Game';
+import { RuleEngine } from '../../src/rules/RuleEngine';
+import { StandardRules } from '../../src/rules/StandardRules';
+import { JumpOwnRules } from '../../src/rules/JumpOwnRules';
+import { Player } from '../../src/types';
+import { InternationalDraughtsRules } from '../../examples/InternationalDraughts';
+import { CrazyCheckersRules } from '../../examples/CrazyCheckers';
+
+/** Deterministic LCG so games are reproducible. */
+function makeRng(seed: number): () => number {
+  let s = seed % 2147483647;
+  if (s <= 0) s += 2147483646;
+  return () => {
+    s = (s * 16807) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+interface PlayResult {
+  plies: number;
+  endedByGameOver: boolean;
+  winner: Player | null;
+  redCount: number;
+  blackCount: number;
+}
+
+/**
+ * Plays a complete game with a seeded pseudo-random policy until the game is
+ * over or limits are hit. Asserts, every ply, that the game stays internally
+ * consistent — the key invariant being: if the player to move has no legal
+ * move, the game MUST report itself as over.
+ */
+function playGame(engine: RuleEngine, seed: number, maxPlies = 400, drawAfterQuietPlies = 80): PlayResult {
+  const rng = makeRng(seed);
+  const game = new Game({ ruleEngine: engine });
+
+  let plies = 0;
+  let quiet = 0;
+
+  while (!game.isGameOver() && plies < maxPlies) {
+    const moves = game.getAllPossibleMoves();
+
+    // Core invariant: a player with no moves means the game is over.
+    if (moves.length === 0) {
+      expect(game.isGameOver()).toBe(true);
+      break;
+    }
+
+    const totalBefore =
+      game.getBoard().getPieceCount(Player.RED) + game.getBoard().getPieceCount(Player.BLACK);
+
+    const move = moves[Math.floor(rng() * moves.length)]!;
+    // Every generated move must be applicable (generation/validation agree).
+    expect(() => game.makeMove(move)).not.toThrow();
+
+    const totalAfter =
+      game.getBoard().getPieceCount(Player.RED) + game.getBoard().getPieceCount(Player.BLACK);
+    quiet = totalAfter < totalBefore ? 0 : quiet + 1;
+    plies++;
+
+    if (quiet > drawAfterQuietPlies) break; // avoid endless king shuffling
+  }
+
+  return {
+    plies,
+    endedByGameOver: game.isGameOver(),
+    winner: game.getWinner(),
+    redCount: game.getBoard().getPieceCount(Player.RED),
+    blackCount: game.getBoard().getPieceCount(Player.BLACK),
+  };
+}
+
+const ENGINES: { name: string; make: () => RuleEngine }[] = [
+  { name: 'Standard', make: () => new StandardRules(8) },
+  { name: 'Jump Your Own Man', make: () => new JumpOwnRules(8) },
+  { name: 'International Draughts', make: () => new InternationalDraughtsRules(10) },
+  { name: 'Crazy Checkers', make: () => new CrazyCheckersRules(8) },
+];
+
+describe('Full playthrough', () => {
+  for (const { name, make } of ENGINES) {
+    describe(name, () => {
+      it('plays many complete games without crashing or getting stuck', () => {
+        let decisive = 0;
+        for (let seed = 1; seed <= 8; seed++) {
+          const result = playGame(make(), seed);
+          // The game never gets stuck: it either reported game-over or we hit a
+          // benign limit (long quiet game), with no exception thrown.
+          if (result.endedByGameOver) {
+            decisive++;
+            // A reported game-over must be backed by the real position: either a
+            // side is eliminated, or the loser genuinely has no move.
+            const eliminated = result.redCount === 0 || result.blackCount === 0;
+            if (eliminated) {
+              const winner = result.redCount === 0 ? Player.BLACK : Player.RED;
+              expect(result.winner).toBe(winner);
+            }
+          }
+        }
+        // At least some games should reach a real conclusion (not all time out).
+        expect(decisive).toBeGreaterThan(0);
+      });
+    });
+  }
+});

--- a/tests/integration/Regressions.test.ts
+++ b/tests/integration/Regressions.test.ts
@@ -1,0 +1,81 @@
+import { Game } from '../../src/core/Game';
+import { Board } from '../../src/core/Board';
+import { Position } from '../../src/core/Position';
+import { StandardRules } from '../../src/rules/StandardRules';
+import { RegularPiece } from '../../src/pieces/RegularPiece';
+import { KingPiece } from '../../src/pieces/KingPiece';
+import { Player } from '../../src/types';
+
+const RED = Player.RED;
+const BLACK = Player.BLACK;
+
+/**
+ * Regression coverage for two bugs found by the full-playthrough simulation:
+ *  1. A king's turning multi-capture (whose start and end are not on one
+ *     diagonal) was generated but then rejected by validation.
+ *  2. A stalemate (the player to move has pieces but no legal move) was not
+ *     reported as game-over, leaving the game stuck.
+ */
+describe('Regressions — full-game correctness', () => {
+  describe('king turning multi-capture', () => {
+    // RED king at (4,4): jump NE over (3,5) to (2,6), then NW over (1,5) to (0,4).
+    // The sequence turns, so from (4,4) to (0,4) is not a single diagonal.
+    const board = new Board(8)
+      .setPiece(new Position(4, 4), new KingPiece(RED))
+      .setPiece(new Position(3, 5), new RegularPiece(BLACK))
+      .setPiece(new Position(1, 5), new RegularPiece(BLACK));
+    const rules = new StandardRules();
+
+    it('is generated as a single move with two captures', () => {
+      const moves = rules.getPossibleMoves(board, new Position(4, 4));
+      const doubleJump = moves.find(m => m.getCaptureCount() === 2);
+      expect(doubleJump).toBeDefined();
+      expect(doubleJump!.to.equals(new Position(0, 4))).toBe(true);
+      expect(doubleJump!.steps.length).toBe(2);
+    });
+
+    it('passes validation (generation and validation agree)', () => {
+      const doubleJump = rules.getPossibleMoves(board, new Position(4, 4)).find(m => m.getCaptureCount() === 2)!;
+      expect(rules.validateMove(board, doubleJump)).toBe(true);
+    });
+
+    it('applies correctly through the Game controller', () => {
+      class Setup extends StandardRules {
+        override getInitialBoard(): Board {
+          return board;
+        }
+      }
+      const game = new Game({ ruleEngine: new Setup() });
+      const doubleJump = game.getPossibleMoves(new Position(4, 4)).find(m => m.getCaptureCount() === 2)!;
+      expect(game.makeMove(doubleJump)).toBe(true);
+
+      const after = game.getBoard();
+      expect(after.getPiece(new Position(0, 4))?.isKing()).toBe(true); // king landed
+      expect(after.isEmpty(new Position(3, 5))).toBe(true);            // both captured
+      expect(after.isEmpty(new Position(1, 5))).toBe(true);
+      expect(after.getPieceCount(BLACK)).toBe(0);
+    });
+  });
+
+  describe('stalemate detection', () => {
+    // RED man at (7,0) is fully blocked: its only forward square (6,1) holds a
+    // BLACK piece and the capture-landing (5,2) is occupied too. RED, to move,
+    // has no legal move and therefore loses.
+    class Stalemate extends StandardRules {
+      override getInitialBoard(): Board {
+        return new Board(8)
+          .setPiece(new Position(7, 0), new RegularPiece(RED))
+          .setPiece(new Position(6, 1), new RegularPiece(BLACK))
+          .setPiece(new Position(5, 2), new RegularPiece(BLACK));
+      }
+    }
+
+    it('reports the game as over with the opponent as winner', () => {
+      const game = new Game({ ruleEngine: new Stalemate() });
+      expect(game.getCurrentPlayer()).toBe(RED);
+      expect(game.getAllPossibleMoves()).toHaveLength(0);
+      expect(game.isGameOver()).toBe(true);
+      expect(game.getWinner()).toBe(BLACK);
+    });
+  });
+});


### PR DESCRIPTION
A QA pass with a randomized full-playthrough simulation found two game-breaking bugs that the unit tests missed. Both are fixed here, with regression tests.

## Bugs found & fixed
1. **Stuck games on stalemate.** `StandardRules.isGameOver(board)` guesses whose turn it is from a piece-count parity heuristic (the interface only passes the board) — wrong after the first non-capture move. A player with pieces but no legal move often wasn't detected as game-over, leaving the game stuck. **Fix:** `Game` now computes game-over/winner from the *actual* player to move + piece counts.
2. **King turning multi-captures generated but rejected.** `KingPiece` built multi-jumps as a single stepless `Move` whose from→to isn't diagonal, so `DiagonalMoveValidator` rejected them. **Fix:** `KingPiece` emits explicit per-jump `steps`; `MultiStepMoveValidator` accepts flying capture steps.

Also simplified `InternationalDraughtsRules` to extend `StandardRules` (10×10, 4-row setup), removing ~150 lines of redundant overrides whose custom king validation rejected the core's correct multi-capture moves.

## Verification
- `tests/integration/FullPlaythrough.test.ts`: plays many complete seeded games for **all four rule sets** — asserts no crash, no stuck state (no-moves ⇒ game over), and generation/validation agreement on every move.
- `tests/integration/Regressions.test.ts`: pins both fixes precisely.
- Verified a capture end-to-end in a real browser (piece removed, turn passes, mandatory-jump cue correct).
- Full suite **327 tests** green; coverage ~92/82/88/94; lint, typecheck, both builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)