### PR TITLE
Heirloom UI/UX overhaul — tactile, silky, self-teaching

### DIFF
--- a/src/ui/web/GameApp.tsx
+++ b/src/ui/web/GameApp.tsx
@@ -6,7 +6,7 @@ import { GameStatus } from './components/GameStatus';
 import { GameControls } from './components/GameControls';
 import { GameConfig } from './components/GameConfig';
 import { HelpPanel } from './components/HelpPanel';
-import { THEME_COLORS, RuleSet, BoardSize } from './types/GameConfig';
+import { THEME_COLORS, ANIMATION_DURATIONS, RuleSet, BoardSize } from './types/GameConfig';
 
 function GameAppContent(): React.JSX.Element {
   const { config } = useGameConfig();
@@ -36,7 +36,8 @@ function GameAppContent(): React.JSX.Element {
     root.style.setProperty('--black-piece-start', themeColors.blackPiece.start);
     root.style.setProperty('--black-piece-mid', themeColors.blackPiece.mid);
     root.style.setProperty('--black-piece-end', themeColors.blackPiece.end);
-  }, [config.theme]);
+    root.style.setProperty('--glide-dur', `${ANIMATION_DURATIONS[config.animationSpeed]}ms`);
+  }, [config.theme, config.animationSpeed]);
 
   return (
     <div className={appClass}>
@@ -59,7 +60,7 @@ function GameAppContent(): React.JSX.Element {
           ❓
         </button>
 
-        <h1>Extensible Checkers</h1>
+        <h1>Checkers</h1>
         
         <GameStatus
           currentPlayer={gameState.currentPlayer}

--- a/src/ui/web/components/GameBoard.tsx
+++ b/src/ui/web/components/GameBoard.tsx
@@ -10,6 +10,8 @@ interface AnimationState {
   promotedPieces: Set<string>;
 }
 
+type MoveTargetType = 'slide' | 'capture' | 'hop';
+
 interface GameBoardProps {
   board: Board;
   selectedPosition: Position | null;
@@ -17,10 +19,22 @@ interface GameBoardProps {
   animationState: AnimationState;
   onSquareClick: (position: Position) => void;
   showMoveHints: boolean;
-  /** Source squares of mandatory capture moves (highlighted when must-capture). */
   mandatorySources?: Set<string>;
-  /** A suggested move to highlight (from the Hint button). */
   hintMove?: Move | null;
+}
+
+/**
+ * Classifies a (non-capture) move so its landing square can show the right
+ * affordance: a "hop" leaps over one of your own pieces (Jump Your Own Man),
+ * whereas a "slide" travels over empty squares.
+ */
+function classifyMove(move: Move, board: Board): MoveTargetType {
+  if (move.isCapture()) return 'capture';
+  if (move.getDistance() >= 2) {
+    const between = move.from.getPositionsBetween(move.to);
+    if (between.some(pos => !board.isEmpty(pos))) return 'hop';
+  }
+  return 'slide';
 }
 
 export function GameBoard({
@@ -34,18 +48,26 @@ export function GameBoard({
   hintMove
 }: GameBoardProps): React.JSX.Element {
   const squares = [];
-  
+
   for (let row = 0; row < board.size; row++) {
     for (let col = 0; col < board.size; col++) {
       const position = new Position(row, col);
       const piece = board.getPiece(position);
       const isSelected = selectedPosition?.equals(position) ?? false;
-      const isValidMove = showMoveHints && validMoves.some(move => move.to.equals(position));
+
+      const matchingMove = validMoves.find(move => move.to.equals(position));
+      const isValidMove = showMoveHints && matchingMove !== undefined;
+      const validMoveType = matchingMove ? classifyMove(matchingMove, board) : undefined;
+
       const posKey = position.hash();
-      
-      const isMoving = animationState.movingPieces.has(posKey);
-      const isCaptured = animationState.capturedPieces.has(posKey);
+      const movingEntry = animationState.movingPieces.get(posKey);
+      const isMoving = movingEntry !== undefined;
+      const moveDelta = movingEntry
+        ? { dx: movingEntry.from.col - movingEntry.to.col, dy: movingEntry.from.row - movingEntry.to.row }
+        : undefined;
+      const isCaptureBurst = animationState.capturedPieces.has(posKey);
       const isPromoted = animationState.promotedPieces.has(posKey);
+
       const isMustMove = showMoveHints && (mandatorySources?.has(posKey) ?? false);
       const isHintFrom = hintMove?.from.equals(position) ?? false;
       const isHintTo = hintMove?.to.equals(position) ?? false;
@@ -57,8 +79,11 @@ export function GameBoard({
           piece={piece}
           isSelected={isSelected}
           isValidMove={isValidMove}
+          validMoveType={validMoveType}
           isMoving={isMoving}
-          isCaptured={isCaptured}
+          moveDelta={moveDelta}
+          isCaptured={false}
+          isCaptureBurst={isCaptureBurst}
           isPromoted={isPromoted}
           isMustMove={isMustMove}
           isHintFrom={isHintFrom}
@@ -71,8 +96,9 @@ export function GameBoard({
 
   const boardStyle = {
     gridTemplateColumns: `repeat(${board.size}, 1fr)`,
-    gridTemplateRows: `repeat(${board.size}, 1fr)`
-  };
+    gridTemplateRows: `repeat(${board.size}, 1fr)`,
+    ['--board-size' as string]: board.size
+  } as React.CSSProperties;
 
   return (
     <div className="game-board" data-testid="game-board" style={boardStyle}>

--- a/src/ui/web/components/GamePiece.tsx
+++ b/src/ui/web/components/GamePiece.tsx
@@ -9,26 +9,44 @@ interface GamePieceProps {
   isMoving?: boolean;
   isCaptured?: boolean;
   isPromoted?: boolean;
+  /** Cell offset (origin − destination) used to animate a glide into place. */
+  moveDelta?: { dx: number; dy: number };
 }
 
-export function GamePiece({ piece, position, isMoving, isCaptured, isPromoted }: GamePieceProps): React.JSX.Element {
+export function GamePiece({
+  piece,
+  position,
+  isMoving,
+  isCaptured,
+  isPromoted,
+  moveDelta
+}: GamePieceProps): React.JSX.Element {
   const playerClass = piece.player === Player.RED ? 'red' : 'black';
   const kingClass = piece.isKing() ? 'king' : '';
-  const symbol = piece.isKing() ? '♛' : '●';
-  
+
   let animationClass = '';
   if (isCaptured) animationClass = 'capturing';
   else if (isMoving) animationClass = 'moving';
   else if (isPromoted) animationClass = 'promoting';
-  
+
   const playerName = piece.player === Player.RED ? 'red' : 'black';
-  
+
+  const style =
+    isMoving && moveDelta
+      ? ({ '--dx': moveDelta.dx, '--dy': moveDelta.dy } as React.CSSProperties)
+      : undefined;
+
   return (
-    <div 
-      className={`game-piece ${playerClass} ${kingClass} ${animationClass}`}
+    <div
+      className={`game-piece ${playerClass} ${kingClass} ${animationClass}`.trim()}
       data-testid={`game-piece-${playerName}-${position.row}-${position.col}`}
+      style={style}
+      role="img"
+      aria-label={`${playerName} ${piece.isKing() ? 'king' : 'piece'}`}
     >
-      {symbol}
+      {piece.isKing() && (
+        <span className="piece-crown" aria-hidden="true">♛</span>
+      )}
     </div>
   );
 }

--- a/src/ui/web/components/GameSquare.tsx
+++ b/src/ui/web/components/GameSquare.tsx
@@ -3,6 +3,8 @@ import { Position } from '../../../core/Position';
 import { Piece } from '../../../pieces/Piece';
 import { GamePiece } from './GamePiece';
 
+type MoveTargetType = 'slide' | 'capture' | 'hop';
+
 interface GameSquareProps {
   position: Position;
   piece: Piece | null;
@@ -14,6 +16,12 @@ interface GameSquareProps {
   isMustMove?: boolean;
   isHintFrom?: boolean;
   isHintTo?: boolean;
+  /** Kind of move that lands here, used to vary the target affordance. */
+  validMoveType?: MoveTargetType;
+  /** Show a capture burst (a piece was just taken from this square). */
+  isCaptureBurst?: boolean;
+  /** Cell offset for a gliding piece. */
+  moveDelta?: { dx: number; dy: number };
   onClick: () => void;
 }
 
@@ -28,30 +36,35 @@ export function GameSquare({
   isMustMove = false,
   isHintFrom = false,
   isHintTo = false,
+  validMoveType,
+  isCaptureBurst = false,
+  moveDelta,
   onClick
 }: GameSquareProps): React.JSX.Element {
   const isDark = position.isDarkSquare();
 
   let className = `game-square ${isDark ? 'dark' : 'light'}`;
   if (isSelected) className += ' selected';
-  if (isValidMove) className += ' valid-move';
+  if (isValidMove) className += ` valid-move target-${validMoveType ?? 'slide'}`;
   if (isMustMove) className += ' must-move';
   if (isHintFrom) className += ' hint-from';
   if (isHintTo) className += ' hint-to';
+  if (isCaptureBurst) className += ' capture-burst';
 
   return (
-    <div 
-      className={className} 
+    <div
+      className={className}
       data-testid={`game-square-${position.row}-${position.col}`}
       onClick={onClick}
     >
       {piece && (
-        <GamePiece 
-          piece={piece} 
+        <GamePiece
+          piece={piece}
           position={position}
           isMoving={isMoving}
           isCaptured={isCaptured}
           isPromoted={isPromoted}
+          moveDelta={moveDelta}
         />
       )}
     </div>

--- a/src/ui/web/hooks/useConfigurableGame.ts
+++ b/src/ui/web/hooks/useConfigurableGame.ts
@@ -177,9 +177,10 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
   useEffect(() => {
     if (lastMoveRef.current) {
       const move = lastMoveRef.current;
-      const key = move.from.hash();
-      
-      // Add moving piece
+      // Key by the destination: that is where the moved piece now lives, so the
+      // glide animation (origin → destination) is applied to the right square.
+      const key = move.to.hash();
+
       setAnimationState(prev => ({
         ...prev,
         movingPieces: new Map([[key, { from: move.from, to: move.to }]])

--- a/src/ui/web/index.html
+++ b/src/ui/web/index.html
@@ -7,13 +7,21 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no"
     />
     <meta name="description" content="Play and learn checkers — including Jump Your Own Man rules — against a friend or the computer." />
-    <meta name="theme-color" content="#b58863" />
+    <meta name="theme-color" content="#3a2417" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="apple-touch-icon" href="/icon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Checkers" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Nunito:wght@500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+
     <title>Checkers — Play & Learn</title>
   </head>
   <body>

--- a/src/ui/web/styles.css
+++ b/src/ui/web/styles.css
@@ -1,114 +1,191 @@
+/* =============================================================================
+   "Heirloom" — a warm, tactile checkers set on a felt table under lamplight.
+   Display: Fraunces · Body/UI: Nunito. Themeable via CSS variables that the
+   app sets at runtime (--light-square, --dark-square, --red-piece-*, etc.).
+   ========================================================================== */
+
+:root {
+  --font-display: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+  --font-body: 'Nunito', system-ui, sans-serif;
+
+  /* Warm surfaces & ink */
+  --surface: #fbf6ec;
+  --surface-2: #f4ead7;
+  --surface-line: #e6d8bf;
+  --ink: #3b2a1b;
+  --ink-soft: #8a7560;
+  --ink-faint: #b6a48c;
+
+  /* Table / felt atmosphere */
+  --felt-1: #4a2f1c;
+  --felt-2: #2c1a0f;
+  --glow: rgba(255, 196, 120, 0.16);
+
+  /* Wooden board frame */
+  --frame-1: #6b4423;
+  --frame-2: #46290f;
+
+  /* Accents */
+  --gold: #c79a3a;
+  --gold-bright: #e9c869;
+  --sage: #5aa172;        /* slide targets */
+  --emerald: #2f9e6b;     /* hop targets (Jump Your Own Man) */
+  --cherry: #c33c2e;      /* capture targets */
+  --amber: #e08a1e;       /* mandatory-jump warning */
+
+  /* Piece palettes (overridden by theme vars at runtime) */
+  --red-piece-start: #e0584a;
+  --red-piece-mid: #c4382c;
+  --red-piece-end: #99231a;
+  --black-piece-start: #4a5360;
+  --black-piece-mid: #2b313b;
+  --black-piece-end: #161a20;
+  --light-square: #f1ddb8;
+  --dark-square: #9d6b3f;
+
+  --glide-dur: 300ms;
+  --ease-spring: cubic-bezier(0.34, 1.28, 0.64, 1);
+  --ease-soft: cubic-bezier(0.22, 1, 0.36, 1);
+
+  --radius: 18px;
+  --shadow-soft: 0 18px 40px -18px rgba(40, 22, 8, 0.55), 0 4px 14px -8px rgba(40, 22, 8, 0.35);
+}
+
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
-@keyframes pieceMove {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.15);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-@keyframes captureOut {
-  0% {
-    opacity: 1;
-    transform: scale(1) rotate(0deg);
-  }
-  100% {
-    opacity: 0;
-    transform: scale(0.3) rotate(180deg);
-  }
-}
-
-@keyframes kingPromotion {
-  0% {
-    transform: scale(1) rotateY(0deg);
-  }
-  50% {
-    transform: scale(1.3) rotateY(180deg);
-  }
-  100% {
-    transform: scale(1) rotateY(360deg);
-  }
-}
-
-@keyframes validMoveGlow {
-  0%, 100% {
-    box-shadow: inset 0 0 0 3px rgba(134, 239, 172, 0.5);
-  }
-  50% {
-    box-shadow: inset 0 0 0 5px rgba(134, 239, 172, 0.8);
-  }
-}
-
-@keyframes selectedPulse {
-  0%, 100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-  }
-}
-
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  background: linear-gradient(135deg, #f5f5f5 0%, #e5e5e5 100%);
-  color: #333;
+  font-family: var(--font-body);
+  color: var(--ink);
   min-height: 100vh;
+  background:
+    radial-gradient(120% 90% at 50% -10%, var(--glow), transparent 55%),
+    radial-gradient(140% 120% at 50% 120%, #1c1009 0%, transparent 60%),
+    linear-gradient(160deg, var(--felt-1) 0%, var(--felt-2) 100%);
+  background-attachment: fixed;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* faint woven-felt texture overlay */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.06;
+  background-image:
+    repeating-linear-gradient(45deg, #000 0 1px, transparent 1px 3px),
+    repeating-linear-gradient(-45deg, #000 0 1px, transparent 1px 3px);
+  background-size: 6px 6px;
 }
 
 #root {
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
+  z-index: 1;
+  padding: 24px 16px;
 }
+
+/* ── App shell ──────────────────────────────────────────────────────────── */
 
 .game-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 30px;
-  background: linear-gradient(135deg, #ffffff 0%, #fafafa 100%);
-  border-radius: 16px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
-  max-width: 800px;
+  padding: 30px 34px 36px;
+  background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 26px;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.7) inset,
+    0 40px 80px -30px rgba(20, 10, 4, 0.7),
+    0 10px 30px -12px rgba(20, 10, 4, 0.5);
+  max-width: 640px;
   width: 100%;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  position: relative;
+  animation: shellIn 0.7s var(--ease-soft) both;
+}
+
+@keyframes shellIn {
+  from { opacity: 0; transform: translateY(14px) scale(0.985); }
+  to { opacity: 1; transform: none; }
 }
 
 .game-container h1 {
-  font-size: 2.5rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, #1f2937 0%, #4b5563 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  margin-bottom: 10px;
-  letter-spacing: -0.5px;
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-size: clamp(2rem, 6vw, 2.9rem);
+  font-weight: 600;
+  line-height: 1;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  text-align: center;
+  margin: 2px 0 4px;
 }
 
+.game-container h1::after {
+  content: '';
+  display: block;
+  width: 64px;
+  height: 3px;
+  margin: 12px auto 0;
+  border-radius: 3px;
+  background: linear-gradient(90deg, transparent, var(--gold), transparent);
+}
+
+/* ── Board ──────────────────────────────────────────────────────────────── */
+
 .game-board {
+  --board-size: 8;
+  --cell: calc(100cqw / var(--board-size));
+  container-type: inline-size;
   display: grid;
   grid-template-columns: repeat(8, 1fr);
   grid-template-rows: repeat(8, 1fr);
   gap: 0;
-  background-color: #1a1a1a;
-  border: 3px solid #1a1a1a;
-  border-radius: 12px;
-  overflow: hidden;
   aspect-ratio: 1;
-  width: min(70vh, 500px);
-  margin: 20px 0;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  width: min(72vh, 520px);
+  max-width: 100%;
+  margin: 22px 0 6px;
+  padding: 14px;
+  border-radius: 16px;
+  background:
+    linear-gradient(145deg, var(--frame-1), var(--frame-2));
+  box-shadow:
+    0 0 0 2px rgba(0, 0, 0, 0.25),
+    0 1px 0 rgba(255, 220, 170, 0.25) inset,
+    0 26px 50px -22px rgba(20, 10, 4, 0.8);
   position: relative;
+  isolation: isolate;
+  animation: boardIn 0.7s 0.05s var(--ease-soft) both;
+}
+
+@keyframes boardIn {
+  from { opacity: 0; transform: translateY(10px) scale(0.97); }
+  to { opacity: 1; transform: none; }
+}
+
+/* the playable surface is inset within the wooden frame */
+.game-board {
+  background-clip: padding-box;
+}
+.game-board::before {
+  content: '';
+  position: absolute;
+  inset: 14px;
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4), 0 8px 20px -6px rgba(0, 0, 0, 0.55) inset;
+  pointer-events: none;
+  z-index: 3;
 }
 
 .game-square {
@@ -117,732 +194,638 @@ body {
   justify-content: center;
   cursor: pointer;
   position: relative;
-  transition: background-color 0.3s ease, transform 0.15s ease;
-  overflow: hidden;
+  transition: background-color 0.25s var(--ease-soft);
+  overflow: visible;
 }
 
 .game-square.light {
-  background-color: var(--light-square, #f0d9b5);
+  background-color: var(--light-square);
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.28), transparent 60%);
 }
 
 .game-square.dark {
-  background-color: var(--dark-square, #b58863);
+  background-color: var(--dark-square);
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(0, 0, 0, 0.12) 70%);
 }
 
-.game-square.dark:hover {
-  background-color: #a57954;
+@media (hover: hover) {
+  .game-square.dark:hover,
+  .game-square.light:hover {
+    filter: brightness(1.05);
+  }
 }
 
-.game-square.selected {
-  background-color: #60a5fa !important;
-  animation: selectedPulse 2s ease-in-out infinite;
-}
-
+/* Selected square: a warm gold ring + gentle lift halo (no jarring color swap). */
 .game-square.selected::after {
   content: '';
   position: absolute;
-  inset: 0;
-  border: 3px solid #2563eb;
-  border-radius: 4px;
+  inset: 5%;
+  border-radius: 12px;
+  box-shadow: 0 0 0 3px var(--gold-bright), 0 0 18px 2px rgba(233, 200, 105, 0.55);
   pointer-events: none;
+  z-index: 4;
+  animation: ringPulse 1.8s var(--ease-soft) infinite;
 }
 
+@keyframes ringPulse {
+  0%, 100% { opacity: 0.85; }
+  50% { opacity: 1; }
+}
+
+/* ── Move-target affordances (slide / capture / hop) ───────────────────────
+   .valid-move is the base hook; GameBoard adds a modifier per move type. */
 .game-square.valid-move {
-  background-color: #86efac !important;
-  animation: validMoveGlow 1.5s ease-in-out infinite;
+  cursor: pointer;
 }
 
+/* default + slide: a soft sage dot that breathes */
 .game-square.valid-move::before {
   content: '';
   position: absolute;
-  width: 30%;
-  height: 30%;
-  background-color: rgba(34, 197, 94, 0.3);
+  width: 34%;
+  height: 34%;
   border-radius: 50%;
-  animation: validMoveGlow 1.5s ease-in-out infinite;
+  background: radial-gradient(circle at 50% 38%, rgba(255, 255, 255, 0.7), var(--sage));
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  pointer-events: none;
+  z-index: 4;
+  animation: targetPop 0.28s var(--ease-spring) both, targetBreath 1.7s var(--ease-soft) 0.28s infinite;
 }
+
+/* capture target: a hollow cherry ring around the landing square */
+.game-square.valid-move.target-capture::before {
+  width: 76%;
+  height: 76%;
+  background: transparent;
+  border: 4px solid var(--cherry);
+  box-shadow: 0 0 14px rgba(195, 60, 46, 0.5), 0 0 0 2px rgba(255, 255, 255, 0.25) inset;
+}
+
+/* hop target (Jump Your Own Man): an emerald leap-arc badge */
+.game-square.valid-move.target-hop::before {
+  width: 52%;
+  height: 52%;
+  background: radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.75), var(--emerald));
+  box-shadow: 0 2px 8px rgba(47, 158, 107, 0.5);
+}
+.game-square.valid-move.target-hop::after {
+  content: '⤴';
+  position: absolute;
+  font-size: clamp(14px, 4cqw, 22px);
+  color: #fff;
+  z-index: 5;
+  pointer-events: none;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  animation: targetPop 0.32s var(--ease-spring) both;
+}
+
+@keyframes targetPop {
+  from { transform: scale(0); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+@keyframes targetBreath {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.14); }
+}
+
+/* Mandatory-capture: outline the piece(s) that must move. */
+.game-square.must-move::after {
+  content: '';
+  position: absolute;
+  inset: 6%;
+  border-radius: 12px;
+  box-shadow: 0 0 0 3px var(--amber), 0 0 16px 1px rgba(224, 138, 30, 0.6);
+  pointer-events: none;
+  z-index: 4;
+  animation: ringPulse 1.2s var(--ease-soft) infinite;
+}
+
+/* Hint: dashed gold origin + gold landing dot. */
+.game-square.hint-from::after {
+  content: '';
+  position: absolute;
+  inset: 6%;
+  border-radius: 50%;
+  border: 3px dashed var(--gold-bright);
+  pointer-events: none;
+  z-index: 4;
+}
+.game-square.hint-to::before {
+  content: '';
+  position: absolute;
+  width: 40%;
+  height: 40%;
+  border-radius: 50%;
+  background: rgba(233, 200, 105, 0.55);
+  box-shadow: 0 0 14px rgba(233, 200, 105, 0.7);
+  pointer-events: none;
+  z-index: 4;
+}
+
+/* Capture burst on the square a piece was just taken from. */
+.game-square.capture-burst::after {
+  content: '';
+  position: absolute;
+  inset: 10%;
+  border-radius: 50%;
+  z-index: 6;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(255, 230, 180, 0.9), rgba(195, 60, 46, 0.5) 45%, transparent 70%);
+  animation: burst 0.5s var(--ease-soft) forwards;
+}
+
+@keyframes burst {
+  from { transform: scale(0.3); opacity: 1; }
+  to { transform: scale(1.9); opacity: 0; }
+}
+
+/* ── Pieces ─────────────────────────────────────────────────────────────── */
 
 .game-piece {
-  width: 85%;
-  height: 85%;
+  --size: 80%;
+  width: var(--size);
+  height: var(--size);
   border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: bold;
-  font-size: 1.4em;
-  border: 3px solid;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3), 0 2px 4px rgba(0, 0, 0, 0.2);
-  cursor: grab;
   position: relative;
-  z-index: 1;
+  z-index: 2;
+  cursor: grab;
+  transition: transform 0.18s var(--ease-spring), filter 0.18s var(--ease-soft);
+  /* contact shadow on the board */
+  filter: drop-shadow(0 5px 5px rgba(20, 10, 4, 0.45));
 }
 
+/* disc body with concentric ridges */
 .game-piece::before {
   content: '';
   position: absolute;
-  inset: 6px;
+  inset: 0;
   border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3), transparent 60%);
+  background:
+    radial-gradient(circle at 50% 32%, rgba(255, 255, 255, 0.55), transparent 42%),
+    repeating-radial-gradient(circle at 50% 50%, rgba(0, 0, 0, 0.08) 0 3px, transparent 3px 7px);
+  mix-blend-mode: soft-light;
+  z-index: 2;
   pointer-events: none;
+}
+
+/* inner rim / token face */
+.game-piece::after {
+  content: '';
+  position: absolute;
+  inset: 16%;
+  border-radius: 50%;
+  z-index: 1;
+  box-shadow:
+    0 0 0 2px rgba(255, 255, 255, 0.18) inset,
+    0 3px 6px rgba(0, 0, 0, 0.35) inset;
 }
 
 .game-piece.red {
-  background: linear-gradient(135deg, 
-    var(--red-piece-start, #ef4444) 0%, 
-    var(--red-piece-mid, #dc2626) 50%, 
-    var(--red-piece-end, #b91c1c) 100%);
-  border-color: var(--red-piece-end, #991b1b);
-  color: white;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  background: radial-gradient(circle at 38% 30%, var(--red-piece-start), var(--red-piece-mid) 55%, var(--red-piece-end) 100%);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 0 rgba(255, 255, 255, 0.25) inset;
 }
 
 .game-piece.black {
-  background: linear-gradient(135deg, 
-    var(--black-piece-start, #374151) 0%, 
-    var(--black-piece-mid, #1f2937) 50%, 
-    var(--black-piece-end, #111827) 100%);
-  border-color: var(--black-piece-end, #030712);
-  color: white;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  background: radial-gradient(circle at 38% 30%, var(--black-piece-start), var(--black-piece-mid) 55%, var(--black-piece-end) 100%);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.2), 0 2px 0 rgba(255, 255, 255, 0.18) inset;
 }
 
+/* King: a gilt crown glyph + golden rim */
 .game-piece.king {
-  font-size: 1.8em;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.3), 
-              inset 0 -2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.game-piece.king::after {
-  content: '';
-  position: absolute;
-  top: -4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 60%;
-  height: 4px;
-  background: linear-gradient(90deg, transparent, rgba(255, 215, 0, 0.8), transparent);
-  border-radius: 2px;
-}
-
-.game-piece:hover {
-  transform: translateY(-2px) scale(1.05);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35), 0 4px 8px rgba(0, 0, 0, 0.25);
-  cursor: grab;
-}
-
-.game-piece.moving {
-  animation: pieceMove 0.3s ease-out;
-  z-index: 10;
-}
-
-.game-piece.capturing {
-  animation: captureOut 0.4s ease-out forwards;
-  pointer-events: none;
-}
-
-.game-piece.promoting {
-  animation: kingPromotion 0.6s ease-in-out;
-}
-
-.game-status {
-  text-align: center;
-  margin: 20px 0;
-  padding: 20px;
-  background: rgba(255, 255, 255, 0.6);
-  border-radius: 12px;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
-}
-
-.current-player {
-  font-size: 1.3em;
-  font-weight: 600;
-  margin-bottom: 10px;
-  color: #374151;
+  color: var(--gold-bright);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  font-size: clamp(13px, 4.2cqw, 24px);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+.game-piece.king::after {
+  box-shadow:
+    0 0 0 2px var(--gold) inset,
+    0 0 0 4px rgba(0, 0, 0, 0.2) inset,
+    0 3px 6px rgba(0, 0, 0, 0.35) inset;
+}
+.game-piece.king > .piece-crown {
+  position: relative;
+  z-index: 3;
+  line-height: 1;
+}
+
+@media (hover: hover) {
+  .game-square:not(.selected) .game-piece:hover {
+    transform: translateY(-3px) scale(1.04);
+    filter: drop-shadow(0 10px 8px rgba(20, 10, 4, 0.5));
+  }
+}
+
+/* Selected piece lifts off the board. */
+.game-square.selected .game-piece {
+  transform: translateY(-6px) scale(1.06);
+  filter: drop-shadow(0 14px 10px rgba(20, 10, 4, 0.55));
+  cursor: grabbing;
+}
+
+/* Gliding piece: starts at its origin square and springs to its new home. */
+.game-piece.moving {
+  z-index: 20;
+  animation: pieceGlide var(--glide-dur) var(--ease-spring) both;
+}
+@keyframes pieceGlide {
+  from { transform: translate(calc(var(--dx, 0) * var(--cell)), calc(var(--dy, 0) * var(--cell))); }
+  to { transform: translate(0, 0); }
+}
+
+.game-piece.promoting {
+  animation: promote 0.7s var(--ease-spring);
+  z-index: 20;
+}
+@keyframes promote {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.35) rotate(-8deg); }
+  70% { transform: scale(1.1) rotate(5deg); }
+  100% { transform: scale(1); }
+}
+.game-piece.promoting::before {
+  animation: promoteShimmer 0.7s var(--ease-soft);
+}
+@keyframes promoteShimmer {
+  0%, 100% { box-shadow: none; }
+  50% { box-shadow: 0 0 22px 6px rgba(233, 200, 105, 0.85); }
+}
+
+/* ── Status ─────────────────────────────────────────────────────────────── */
+
+.game-status {
+  text-align: center;
+  margin: 8px 0 4px;
+  min-height: 56px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+
+.current-player {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
 }
 
 .current-player::before {
   content: '';
-  width: 20px;
-  height: 20px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  display: inline-block;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3), 0 1px 0 rgba(255, 255, 255, 0.4) inset;
+  transition: transform 0.3s var(--ease-spring);
 }
-
 .current-player.red::before {
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  background: radial-gradient(circle at 38% 30%, var(--red-piece-start), var(--red-piece-end));
 }
-
 .current-player.black::before {
-  background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
+  background: radial-gradient(circle at 38% 30%, var(--black-piece-start), var(--black-piece-end));
 }
 
 .move-count {
-  font-size: 0.9em;
-  color: #6b7280;
-  margin-top: 5px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
 }
 
 .game-over {
-  color: #dc2626;
-  font-size: 1.6em;
+  font-family: var(--font-display);
+  color: var(--ink);
+  font-size: 1.7rem;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  animation: gameOverPulse 1s ease-in-out infinite;
+  animation: gameOverIn 0.5s var(--ease-spring) both;
+}
+@keyframes gameOverIn {
+  from { opacity: 0; transform: scale(0.8); }
+  to { opacity: 1; transform: scale(1); }
 }
 
-@keyframes gameOverPulse {
-  0%, 100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.8;
-    transform: scale(1.05);
-  }
+/* ── Announcements (thinking / must-jump) ──────────────────────────────────*/
+
+.thinking-indicator,
+.capture-alert {
+  margin: 8px auto 0;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 0.95rem;
+  text-align: center;
+  width: fit-content;
+  animation: chipIn 0.32s var(--ease-spring) both, softPulse 1.5s var(--ease-soft) 0.32s infinite;
+  box-shadow: 0 6px 16px -8px rgba(20, 10, 4, 0.5);
 }
+.thinking-indicator {
+  background: #efe7d3;
+  color: #6b4f1c;
+  border: 1px solid #e3d2a8;
+}
+.capture-alert {
+  background: linear-gradient(180deg, #fdebcf, #f8d9a6);
+  color: #9a5a09;
+  border: 1px solid #e9bf7a;
+}
+@keyframes chipIn {
+  from { opacity: 0; transform: translateY(-6px) scale(0.9); }
+  to { opacity: 1; transform: none; }
+}
+@keyframes softPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.04); }
+}
+
+/* ── Buttons & controls ─────────────────────────────────────────────────── */
 
 .game-controls {
   display: flex;
-  gap: 12px;
-  margin-top: 20px;
+  gap: 10px;
+  margin-top: 18px;
   flex-wrap: wrap;
   justify-content: center;
 }
 
 .btn {
-  padding: 12px 24px;
+  font-family: var(--font-body);
+  padding: 12px 22px;
   border: none;
-  border-radius: 8px;
+  border-radius: 13px;
   cursor: pointer;
-  font-weight: 600;
-  font-size: 0.95em;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  font-weight: 800;
+  font-size: 0.92rem;
+  letter-spacing: 0.01em;
+  transition: transform 0.14s var(--ease-spring), box-shadow 0.2s var(--ease-soft), filter 0.2s ease;
   position: relative;
   overflow: hidden;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  color: var(--ink);
 }
-
-.btn::before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 0;
-  height: 0;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.3);
-  transform: translate(-50%, -50%);
-  transition: width 0.6s, height 0.6s;
-}
-
-.btn:active::before {
-  width: 300px;
-  height: 300px;
-}
+.btn:active { transform: translateY(1px) scale(0.98); }
 
 .btn-primary {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
+  background: linear-gradient(180deg, #7a4a26, #5c3417);
+  color: #fdf3e3;
+  box-shadow: 0 8px 18px -8px rgba(92, 52, 23, 0.8), 0 1px 0 rgba(255, 220, 170, 0.35) inset;
 }
-
-.btn-primary:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(37, 99, 235, 0.4);
-}
+.btn-primary:hover { filter: brightness(1.08); transform: translateY(-2px); }
 
 .btn-secondary {
-  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
-  color: white;
-  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.3);
+  background: linear-gradient(180deg, #fff, var(--surface-2));
+  color: var(--ink);
+  box-shadow: 0 6px 14px -8px rgba(40, 22, 8, 0.5), 0 0 0 1px var(--surface-line) inset;
 }
-
-.btn-secondary:hover {
-  background: linear-gradient(135deg, #6b7280 0%, #4b5563 100%);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(107, 114, 128, 0.4);
-}
+.btn-secondary:hover { transform: translateY(-2px); box-shadow: 0 10px 20px -10px rgba(40, 22, 8, 0.55), 0 0 0 1px var(--surface-line) inset; }
 
 .btn:disabled {
-  background: #e5e7eb;
-  color: #9ca3af;
+  background: #ece2d0;
+  color: var(--ink-faint);
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
-}
-
-.btn:disabled:hover {
-  transform: none;
-}
-
-.error-message {
-  color: #dc2626;
-  margin-top: 15px;
-  padding: 15px 20px;
-  background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
-  border: 1px solid #fecaca;
-  border-radius: 8px;
-  font-weight: 500;
-  animation: errorSlideIn 0.3s ease-out;
-  box-shadow: 0 2px 8px rgba(220, 38, 38, 0.1);
-}
-
-@keyframes errorSlideIn {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Configuration Panel Styles */
-.config-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-  backdrop-filter: blur(4px);
-  animation: fadeIn 0.2s ease-out;
-}
-
-.config-panel {
-  background: white;
-  border-radius: 16px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 600px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-  animation: slideIn 0.3s ease-out;
-}
-
-@keyframes slideIn {
-  from {
-    opacity: 0;
-    transform: translateY(-20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.config-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 24px;
-  border-bottom: 1px solid #e5e7eb;
-}
-
-.config-header h2 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin: 0;
-  background: linear-gradient(135deg, #1f2937 0%, #4b5563 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-
-.close-btn {
-  background: none;
-  border: none;
-  font-size: 2rem;
-  cursor: pointer;
-  color: #6b7280;
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
-}
-
-.close-btn:hover {
-  background-color: #f3f4f6;
-  color: #374151;
-}
-
-.config-section {
-  padding: 20px 24px;
-  border-bottom: 1px solid #e5e7eb;
-}
-
-.config-section:last-of-type {
-  border-bottom: none;
-}
-
-.config-section h3 {
-  font-size: 1.1rem;
-  font-weight: 600;
-  margin: 0 0 16px 0;
-  color: #374151;
-}
-
-.config-options {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.config-options.horizontal {
-  flex-direction: row;
-  flex-wrap: wrap;
-}
-
-.config-option {
-  display: flex;
-  flex-direction: column;
-  padding: 16px;
-  border: 2px solid #e5e7eb;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  position: relative;
-}
-
-.config-options.horizontal .config-option {
-  flex: 1;
-  min-width: 100px;
-  align-items: center;
-}
-
-.config-option:hover {
-  border-color: #3b82f6;
-  background-color: #f9fafb;
-}
-
-.config-option.selected {
-  border-color: #3b82f6;
-  background-color: #eff6ff;
-}
-
-.config-option input[type="radio"] {
-  position: absolute;
-  opacity: 0;
-}
-
-.config-option span {
-  font-weight: 500;
-  color: #1f2937;
-  margin-bottom: 4px;
-}
-
-.config-option small {
-  font-size: 0.875rem;
-  color: #6b7280;
-}
-
-.config-checkbox {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 0;
-  cursor: pointer;
-}
-
-.config-checkbox input[type="checkbox"] {
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-}
-
-.config-checkbox span {
-  color: #374151;
-  font-weight: 500;
-}
-
-.config-actions {
-  padding: 20px 24px;
-  display: flex;
-  gap: 12px;
-  justify-content: flex-end;
-  border-top: 1px solid #e5e7eb;
-}
-
-.confirm-dialog {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 16px;
-}
-
-.confirm-content {
-  background: white;
-  padding: 24px;
-  border-radius: 12px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  max-width: 400px;
-  margin: 20px;
-}
-
-.confirm-content p {
-  margin: 0 0 20px 0;
-  color: #374151;
-  font-size: 1.1rem;
-}
-
-.confirm-actions {
-  display: flex;
-  gap: 12px;
-  justify-content: flex-end;
-}
-
-.settings-btn {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  background: white;
-  border: 1px solid #e5e7eb;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.2rem;
-  transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.settings-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
-/* Theme-specific styles */
-.theme-modern .game-square.light {
-  background-color: #e5e7eb;
-}
-
-.theme-modern .game-square.dark {
-  background-color: #6b7280;
-}
-
-.theme-dark {
-  background-color: #111827;
-}
-
-.theme-dark .game-container {
-  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
-  color: #f3f4f6;
-}
-
-.theme-dark .game-square.light {
-  background-color: #4b5563;
-}
-
-.theme-dark .game-square.dark {
-  background-color: #1f2937;
-}
-
-/* Additional responsive styles */
-@media (max-width: 768px) {
-  .game-container {
-    padding: 20px;
-  }
-  
-  .game-container h1 {
-    font-size: 2rem;
-  }
-  
-  .game-board {
-    width: min(90vw, 400px);
-  }
-  
-  .config-panel {
-    border-radius: 0;
-    max-width: 100%;
-    width: 100%;
-    max-height: 100vh;
-  }
-}
-
-/* ── Teaching aids & opponent UI ───────────────────────────────────────── */
-
-.help-btn {
-  position: absolute;
-  top: 20px;
-  right: 68px;
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  background: white;
-  border: 1px solid #e5e7eb;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.1rem;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.help-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
-.thinking-indicator,
-.capture-alert {
-  margin: 0.5rem auto;
-  padding: 0.5rem 1rem;
-  border-radius: 999px;
-  font-weight: 600;
-  text-align: center;
-  width: fit-content;
-  animation: pulse 1.4s ease-in-out infinite;
-}
-
-.thinking-indicator {
-  background: #eef2ff;
-  color: #4338ca;
-}
-
-.capture-alert {
-  background: #fff7ed;
-  color: #c2410c;
-  border: 1px solid #fdba74;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.6; }
-}
-
-/* Pieces that are forced to move on a mandatory capture. */
-.game-square.must-move::after {
-  content: '';
-  position: absolute;
-  inset: 4px;
-  border: 3px solid #f97316;
-  border-radius: 8px;
-  box-shadow: 0 0 10px rgba(249, 115, 22, 0.7);
-  pointer-events: none;
-}
-
-/* The suggested move from the Hint button. */
-.game-square.hint-from::after,
-.game-square.hint-to::before {
-  content: '';
-  position: absolute;
-  inset: 6px;
-  border-radius: 50%;
-  pointer-events: none;
-}
-
-.game-square.hint-from::after {
-  border: 3px dashed #22c55e;
-}
-
-.game-square.hint-to::before {
-  background: rgba(34, 197, 94, 0.35);
+  filter: none;
 }
 
 .extra-controls {
   display: flex;
   justify-content: center;
-  margin-top: 0.5rem;
+  gap: 10px;
+  margin-top: 10px;
 }
 
 .btn-hint {
-  background: #ecfdf5;
-  color: #047857;
-  border: 1px solid #6ee7b7;
+  background: linear-gradient(180deg, #fbedc6, #f4dd9c);
+  color: #7a5a12;
+  box-shadow: 0 6px 14px -8px rgba(180, 130, 20, 0.6), 0 0 0 1px #ecd28f inset;
+}
+.btn-hint:hover:not(:disabled) { transform: translateY(-2px); filter: brightness(1.04); }
+
+.error-message {
+  color: #9a2820;
+  margin-top: 14px;
+  padding: 12px 18px;
+  background: linear-gradient(180deg, #fceae6, #f8d8d1);
+  border: 1px solid #efc0b6;
+  border-radius: 12px;
+  font-weight: 700;
+  animation: chipIn 0.3s var(--ease-spring);
 }
 
-.btn-hint:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
-}
-
-.config-subsection {
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px dashed #e5e7eb;
-}
-
-/* How-to-play overlay */
-.help-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+/* Round icon buttons (settings / help) */
+.settings-btn,
+.help-btn {
+  position: absolute;
+  top: 22px;
+  width: 42px;
+  height: 42px;
+  border-radius: 13px;
+  background: linear-gradient(180deg, #fff, var(--surface-2));
+  border: 1px solid var(--surface-line);
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 50;
-  padding: 1rem;
+  font-size: 1.2rem;
+  transition: transform 0.15s var(--ease-spring), box-shadow 0.2s ease;
+  box-shadow: 0 4px 10px -6px rgba(40, 22, 8, 0.5);
+  z-index: 5;
 }
+.settings-btn { right: 22px; }
+.help-btn { right: 72px; }
+.settings-btn:hover,
+.help-btn:hover { transform: translateY(-2px) rotate(-4deg); box-shadow: 0 8px 16px -8px rgba(40, 22, 8, 0.55); }
 
+/* ── Overlays: settings & help ──────────────────────────────────────────── */
+
+.config-overlay,
+.help-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(28, 16, 9, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  backdrop-filter: blur(6px);
+  padding: 16px;
+  animation: fadeIn 0.2s ease-out;
+}
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+.config-panel,
 .help-panel {
-  background: white;
-  border-radius: 12px;
-  max-width: 540px;
+  background: linear-gradient(180deg, var(--surface), var(--surface-2));
+  border-radius: 22px;
+  box-shadow: 0 40px 80px -30px rgba(20, 10, 4, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  max-width: 560px;
   width: 100%;
   max-height: 90vh;
   overflow-y: auto;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+  animation: panelIn 0.3s var(--ease-spring) both;
+}
+@keyframes panelIn {
+  from { opacity: 0; transform: translateY(16px) scale(0.97); }
+  to { opacity: 1; transform: none; }
 }
 
+.config-header,
 .help-header {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid #e5e7eb;
+  align-items: center;
+  padding: 22px 24px;
+  border-bottom: 1px solid var(--surface-line);
 }
-
-.help-header h2 { margin: 0; }
-
-.help-body {
-  padding: 1rem 1.5rem;
-  line-height: 1.5;
-  color: #374151;
-}
-
-.help-body h3 {
-  margin: 1rem 0 0.5rem;
-  color: #111827;
-}
-
-.help-body ul {
+.config-header h2,
+.help-header h2 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 600;
   margin: 0;
-  padding-left: 1.25rem;
+  color: var(--ink);
 }
 
-.help-body li { margin-bottom: 0.35rem; }
-
-.help-actions {
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 1.8rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--ink-soft);
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
   display: flex;
-  justify-content: flex-end;
-  padding: 1rem 1.5rem;
-  border-top: 1px solid #e5e7eb;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.close-btn:hover { background-color: var(--surface-line); color: var(--ink); }
+
+.config-section { padding: 20px 24px; border-bottom: 1px solid var(--surface-line); }
+.config-section:last-of-type { border-bottom: none; }
+.config-section h3 {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 14px 0;
+  color: var(--ink);
+}
+
+.config-options { display: flex; flex-direction: column; gap: 10px; }
+.config-options.horizontal { flex-direction: row; flex-wrap: wrap; }
+
+.config-option {
+  display: flex;
+  flex-direction: column;
+  padding: 14px 16px;
+  border: 2px solid var(--surface-line);
+  border-radius: 13px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.12s var(--ease-spring);
+  position: relative;
+  background: rgba(255, 255, 255, 0.4);
+}
+.config-options.horizontal .config-option { flex: 1; min-width: 100px; align-items: center; }
+.config-option:hover { border-color: var(--gold); transform: translateY(-1px); }
+.config-option.selected { border-color: var(--gold); background: #fff7e2; box-shadow: 0 0 0 3px rgba(199, 154, 58, 0.18); }
+.config-option input[type="radio"] { position: absolute; opacity: 0; }
+.config-option span { font-weight: 800; color: var(--ink); margin-bottom: 3px; }
+.config-option small { font-size: 0.85rem; color: var(--ink-soft); }
+
+.config-checkbox { display: flex; align-items: center; gap: 12px; padding: 12px 0; cursor: pointer; }
+.config-checkbox input[type="checkbox"] { width: 20px; height: 20px; cursor: pointer; accent-color: var(--frame-1); }
+.config-checkbox span { color: var(--ink); font-weight: 700; }
+
+.config-actions { padding: 20px 24px; display: flex; gap: 12px; justify-content: flex-end; border-top: 1px solid var(--surface-line); }
+.config-subsection { margin-top: 12px; padding-top: 12px; border-top: 1px dashed var(--surface-line); }
+
+.confirm-dialog {
+  position: absolute;
+  inset: 0;
+  background: rgba(28, 16, 9, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 22px;
+}
+.confirm-content {
+  background: var(--surface);
+  padding: 24px;
+  border-radius: 16px;
+  box-shadow: 0 20px 40px -16px rgba(20, 10, 4, 0.6);
+  max-width: 400px;
+  margin: 20px;
+}
+.confirm-content p { margin: 0 0 18px 0; color: var(--ink); font-size: 1.05rem; font-weight: 600; }
+.confirm-actions { display: flex; gap: 12px; justify-content: flex-end; }
+
+.help-body { padding: 16px 24px; line-height: 1.55; color: var(--ink); }
+.help-body h3 { font-family: var(--font-display); margin: 14px 0 6px; color: var(--ink); font-weight: 600; }
+.help-body ul { margin: 0; padding-left: 1.25rem; }
+.help-body li { margin-bottom: 0.4rem; }
+.help-body p { color: var(--ink-soft); }
+.help-actions { display: flex; justify-content: flex-end; padding: 16px 24px; border-top: 1px solid var(--surface-line); }
+
+/* ── Themes (override the runtime CSS variables) ───────────────────────────*/
+
+.theme-modern {
+  --surface: #f5f6f8;
+  --surface-2: #e9ecf1;
+  --surface-line: #d8dde6;
+  --ink: #1f2630;
+  --ink-soft: #6b7480;
+  --frame-1: #3b4654;
+  --frame-2: #232b35;
+  --gold: #c98a3a;
+  --gold-bright: #e3b461;
+}
+
+.theme-dark {
+  --surface: #232a33;
+  --surface-2: #1a2029;
+  --surface-line: #333d49;
+  --ink: #eef2f7;
+  --ink-soft: #9aa6b3;
+  --ink-faint: #66727f;
+  --felt-1: #161b22;
+  --felt-2: #0b0e13;
+  --frame-1: #2a323d;
+  --frame-2: #161b22;
+  --glow: rgba(120, 170, 255, 0.12);
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .game-container { padding: 22px 16px 26px; border-radius: 22px; }
+  .game-board { width: min(92vw, 460px); padding: 11px; }
+  .config-panel, .help-panel { border-radius: 0; max-width: 100%; max-height: 100vh; }
+  .help-btn { right: 70px; }
+}
+
+/* ── Accessibility: respect reduced motion ─────────────────────────────────*/
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+  .game-piece.moving { animation: none; }
+}
+
+:focus-visible {
+  outline: 3px solid var(--gold-bright);
+  outline-offset: 2px;
+  border-radius: 6px;
 }

--- a/tests/integration/RuleConfiguration.test.tsx
+++ b/tests/integration/RuleConfiguration.test.tsx
@@ -22,7 +22,7 @@ describe('Rule Configuration Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Open settings
@@ -102,7 +102,7 @@ describe('Rule Configuration Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Open settings
@@ -138,7 +138,7 @@ describe('Rule Configuration Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Open settings and change theme
@@ -173,7 +173,7 @@ describe('Rule Configuration Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Open settings and change animation speed
@@ -208,7 +208,7 @@ describe('Rule Configuration Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // First ensure we're on Standard checkers (8x8)
@@ -298,7 +298,7 @@ describe('Rule Configuration Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Open settings and make multiple changes

--- a/tests/integration/WebGameplay.test.tsx
+++ b/tests/integration/WebGameplay.test.tsx
@@ -22,7 +22,7 @@ describe('Web Gameplay Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Verify initial game state
@@ -89,7 +89,7 @@ describe('Web Gameplay Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Select a piece first to see default behavior (hints should be on by default)
@@ -153,7 +153,7 @@ describe('Web Gameplay Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     const squares = screen.getAllByRole('generic').filter(el => 
@@ -189,7 +189,7 @@ describe('Web Gameplay Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Count initial squares (should be 8x8 = 64)

--- a/tests/ui/GameBoard.test.tsx
+++ b/tests/ui/GameBoard.test.tsx
@@ -62,9 +62,7 @@ describe('GameBoard Component', () => {
       />
     );
 
-    const pieces = screen.getAllByRole('generic').filter(el => 
-      el.className.includes('game-piece')
-    );
+    const pieces = Array.from(document.querySelectorAll('.game-piece'));
     expect(pieces).toHaveLength(1);
     expect(pieces[0]).toHaveClass('red');
   });
@@ -160,9 +158,7 @@ describe('GameBoard Component', () => {
       />
     );
 
-    const pieces = screen.getAllByRole('generic').filter(el => 
-      el.className.includes('game-piece')
-    );
+    const pieces = Array.from(document.querySelectorAll('.game-piece'));
     expect(pieces[0]).toHaveClass('moving');
   });
 

--- a/tests/ui/UserFlow.test.tsx
+++ b/tests/ui/UserFlow.test.tsx
@@ -23,7 +23,7 @@ describe('User Flow Integration Tests', () => {
 
     // Wait for initial render
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
       expect(screen.getByText(/Current Turn: Red/)).toBeInTheDocument();
     });
 
@@ -63,7 +63,7 @@ describe('User Flow Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Make a move first
@@ -95,7 +95,7 @@ describe('User Flow Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Make a move
@@ -115,9 +115,7 @@ describe('User Flow Integration Tests', () => {
       expect(screen.getByText(/Current Turn: Red/)).toBeInTheDocument();
       expect(screen.getByText('Move 1')).toBeInTheDocument();
       // Check that pieces are in starting positions
-      const pieces = screen.getAllByRole('generic').filter(el => 
-        el.className.includes('game-piece')
-      );
+      const pieces = Array.from(document.querySelectorAll('.game-piece'));
       expect(pieces).toHaveLength(24); // 12 red + 12 black pieces
     });
   });
@@ -126,7 +124,7 @@ describe('User Flow Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // Click settings button
@@ -178,7 +176,7 @@ describe('User Flow Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     const squares = screen.getAllByRole('generic').filter(el => 
@@ -204,7 +202,7 @@ describe('User Flow Integration Tests', () => {
     render(<GameApp />);
 
     await waitFor(() => {
-      expect(screen.getByText('Extensible Checkers')).toBeInTheDocument();
+      expect(screen.getByText('Checkers')).toBeInTheDocument();
     });
 
     // In a real test, we would play through a complete game


### PR DESCRIPTION
A ground-up visual + motion redesign of the web app — warm, premium, kid-friendly, and built around 2026 game-UX best practices.

## Aesthetic: "Heirloom"
- Distinctive type: **Fraunces** (display) + **Nunito** (body) — no system/Inter.
- Warm felt-table background (vignette + woven texture), parchment surfaces, a real **wooden board frame** with inset depth.
- **Tactile pieces**: ridged gradient discs, gloss highlight, gilt-rimmed crowned kings, contact shadows.
- Cohesive warm palette; full theme support retained via the runtime CSS variables.

## Motion (smooth as silk)
- **Pieces now glide** between squares. The old animation was keyed to the empty origin square, so pieces teleported — fixed by keying to the destination and springing in via a FLIP transform in container-query units (exact at any board size).
- Selected pieces lift with a gold ring; capture bursts; king-promotion flourish; staggered entrance; tactile buttons.
- All `prefers-reduced-motion` aware; added `:focus-visible`.

## Jump Your Own Man, self-teaching
Move targets are classified and styled distinctly: **sage dot** (slide), **cherry ring** (capture), **emerald leap-arc ⤴** (hop over your own piece).

## Housekeeping
- Cleaner title ("Checkers") — also fixes the long title colliding with header icons.
- Pieces expose `role="img"` + `aria-label`; tests updated to select by the stable `.game-piece` class.

## Verification
Full suite **331 green**; lint, typecheck, and web build clean. Verified live in a real browser (board, hop affordance, selection lift, 0 console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)