### PR TITLE
Game feel: drag-and-drop, sound + haptics, and a win celebration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,6 +111,15 @@ export default [
     }
   },
   {
+    // Browser-targeted source under the web UI also needs DOM globals.
+    files: ['src/ui/web/**/*.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.browser
+      }
+    }
+  },
+  {
     ignores: ['dist/', 'node_modules/', '*.config.js', 'vite.config.ts', '.early.coverage/']
   }
 ];

--- a/src/ui/web/GameApp.tsx
+++ b/src/ui/web/GameApp.tsx
@@ -9,7 +9,7 @@ import { HelpPanel } from './components/HelpPanel';
 import { THEME_COLORS, ANIMATION_DURATIONS, RuleSet, BoardSize } from './types/GameConfig';
 
 function GameAppContent(): React.JSX.Element {
-  const { config } = useGameConfig();
+  const { config, updateConfig } = useGameConfig();
   const { gameState, actions, canUndo, canRedo, isThinking, mustCapture, mandatorySources, hintMove } =
     useConfigurableGame();
   const [showConfig, setShowConfig] = useState(false);
@@ -58,6 +58,16 @@ function GameAppContent(): React.JSX.Element {
           aria-label="How to Play"
         >
           ❓
+        </button>
+
+        <button
+          className="sound-btn"
+          data-testid="sound-button"
+          onClick={() => updateConfig({ sound: !config.sound })}
+          aria-label={config.sound ? 'Mute sound' : 'Unmute sound'}
+          aria-pressed={config.sound}
+        >
+          {config.sound ? '🔊' : '🔇'}
         </button>
 
         <h1>Checkers</h1>

--- a/src/ui/web/GameApp.tsx
+++ b/src/ui/web/GameApp.tsx
@@ -6,6 +6,7 @@ import { GameStatus } from './components/GameStatus';
 import { GameControls } from './components/GameControls';
 import { GameConfig } from './components/GameConfig';
 import { HelpPanel } from './components/HelpPanel';
+import { Confetti } from './components/Confetti';
 import { THEME_COLORS, ANIMATION_DURATIONS, RuleSet, BoardSize } from './types/GameConfig';
 
 function GameAppContent(): React.JSX.Element {
@@ -39,8 +40,11 @@ function GameAppContent(): React.JSX.Element {
     root.style.setProperty('--glide-dur', `${ANIMATION_DURATIONS[config.animationSpeed]}ms`);
   }, [config.theme, config.animationSpeed]);
 
+  const celebrate = gameState.isGameOver && gameState.winner !== null;
+
   return (
     <div className={appClass}>
+      {celebrate && <Confetti key={gameState.moveHistory.length} />}
       <main className="game-container" role="main">
         <button
           className="settings-btn"

--- a/src/ui/web/GameApp.tsx
+++ b/src/ui/web/GameApp.tsx
@@ -97,6 +97,9 @@ function GameAppContent(): React.JSX.Element {
           validMoves={gameState.validMoves}
           animationState={gameState.animationState}
           onSquareClick={actions.selectPosition}
+          onDragMove={actions.dragMove}
+          currentPlayer={gameState.currentPlayer}
+          locked={isThinking}
           showMoveHints={config.showMoveHints}
           mandatorySources={mandatorySources}
           hintMove={hintMove}

--- a/src/ui/web/components/Confetti.tsx
+++ b/src/ui/web/components/Confetti.tsx
@@ -1,0 +1,52 @@
+import React, { useMemo } from 'react';
+
+interface ConfettiProps {
+  count?: number;
+}
+
+const COLORS = ['#e9c869', '#c33c2e', '#2f9e6b', '#4a5360', '#fbf6ec', '#c79a3a'];
+
+/**
+ * A lightweight, asset-free confetti burst for the win celebration. Pieces are
+ * generated once on mount, so a fresh celebration plays each time it is keyed
+ * back into the tree. Purely decorative (aria-hidden, pointer-events none).
+ */
+export function Confetti({ count = 90 }: ConfettiProps): React.JSX.Element {
+  const bits = useMemo(
+    () =>
+      Array.from({ length: count }, () => ({
+        left: Math.random() * 100,
+        bg: COLORS[Math.floor(Math.random() * COLORS.length)],
+        delay: Math.random() * 0.5,
+        duration: 1.9 + Math.random() * 1.8,
+        spin: Math.round(Math.random() * 6 + 2) * (Math.random() < 0.5 ? -1 : 1),
+        drift: Math.round((Math.random() * 2 - 1) * 70),
+        width: Math.round(6 + Math.random() * 8),
+        height: Math.round(8 + Math.random() * 8)
+      })),
+    [count]
+  );
+
+  return (
+    <div className="confetti" aria-hidden="true">
+      {bits.map((b, i) => (
+        <span
+          key={i}
+          className="confetti-bit"
+          style={
+            {
+              left: `${b.left}%`,
+              background: b.bg,
+              width: `${b.width}px`,
+              height: `${b.height}px`,
+              animationDelay: `${b.delay}s`,
+              animationDuration: `${b.duration}s`,
+              '--spin': `${b.spin * 360}deg`,
+              '--drift': `${b.drift}px`
+            } as React.CSSProperties
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/ui/web/components/GameBoard.tsx
+++ b/src/ui/web/components/GameBoard.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Board } from '../../../core/Board';
 import { Position } from '../../../core/Position';
 import { Move } from '../../../core/Move';
+import { Piece } from '../../../pieces/Piece';
+import { Player } from '../../../types';
 import { GameSquare } from './GameSquare';
+import { playPickup } from '../sound';
 
 interface AnimationState {
   movingPieces: Map<string, { from: Position; to: Position }>;
@@ -18,16 +21,14 @@ interface GameBoardProps {
   validMoves: Move[];
   animationState: AnimationState;
   onSquareClick: (position: Position) => void;
+  onDragMove?: (from: Position, to: Position) => void;
+  currentPlayer?: Player;
+  locked?: boolean;
   showMoveHints: boolean;
   mandatorySources?: Set<string>;
   hintMove?: Move | null;
 }
 
-/**
- * Classifies a (non-capture) move so its landing square can show the right
- * affordance: a "hop" leaps over one of your own pieces (Jump Your Own Man),
- * whereas a "slide" travels over empty squares.
- */
 function classifyMove(move: Move, board: Board): MoveTargetType {
   if (move.isCapture()) return 'capture';
   if (move.getDistance() >= 2) {
@@ -37,18 +38,145 @@ function classifyMove(move: Move, board: Board): MoveTargetType {
   return 'slide';
 }
 
+/** Resolve the board square under a viewport point, if any. */
+function squareAt(x: number, y: number): Position | null {
+  const el = document.elementFromPoint(x, y);
+  const square = el?.closest('[data-testid^="game-square-"]');
+  const id = square?.getAttribute('data-testid');
+  if (!id) return null;
+  const [, , r, c] = id.split('-');
+  const row = Number(r);
+  const col = Number(c);
+  if (Number.isNaN(row) || Number.isNaN(col)) return null;
+  return new Position(row, col);
+}
+
+const DRAG_THRESHOLD = 6;
+
+interface DragVisual {
+  color: 'red' | 'black';
+  king: boolean;
+  size: number;
+}
+
 export function GameBoard({
   board,
   selectedPosition,
   validMoves,
   animationState,
   onSquareClick,
+  onDragMove = (): void => undefined,
+  currentPlayer = Player.RED,
+  locked = false,
   showMoveHints,
   mandatorySources,
   hintMove
 }: GameBoardProps): React.JSX.Element {
-  const squares = [];
+  const [dragVisual, setDragVisual] = useState<DragVisual | null>(null);
+  const [hoverTarget, setHoverTarget] = useState<Position | null>(null);
 
+  const ghostRef = useRef<HTMLDivElement>(null);
+  const justDraggedRef = useRef(false);
+  const dragRef = useRef<{
+    from: Position;
+    startX: number;
+    startY: number;
+    moved: boolean;
+    visual: DragVisual;
+  } | null>(null);
+
+  // Latest values for the always-on window listeners (avoids stale closures).
+  const validMovesRef = useRef(validMoves);
+  validMovesRef.current = validMoves;
+  const onSquareClickRef = useRef(onSquareClick);
+  onSquareClickRef.current = onSquareClick;
+  const onDragMoveRef = useRef(onDragMove);
+  onDragMoveRef.current = onDragMove;
+
+  const positionGhost = (x: number, y: number): void => {
+    if (ghostRef.current) {
+      ghostRef.current.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`;
+    }
+  };
+
+  useEffect(() => {
+    const handleMove = (e: PointerEvent): void => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const dist = Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY);
+      if (!drag.moved && dist < DRAG_THRESHOLD) return;
+
+      if (!drag.moved) {
+        drag.moved = true;
+        onSquareClickRef.current(drag.from); // select → reveals valid targets
+        setDragVisual(drag.visual); // reveal the lifted ghost
+        playPickup();
+        const { clientX, clientY } = e;
+        requestAnimationFrame(() => positionGhost(clientX, clientY)); // once mounted
+      }
+      positionGhost(e.clientX, e.clientY);
+
+      const over = squareAt(e.clientX, e.clientY);
+      const valid = over ? validMovesRef.current.some(m => m.to.equals(over)) : false;
+      setHoverTarget(prev => {
+        if (valid && over) return prev && prev.equals(over) ? prev : over;
+        return prev ? null : prev;
+      });
+    };
+
+    const handleUp = (e: PointerEvent): void => {
+      const drag = dragRef.current;
+      dragRef.current = null;
+      if (!drag) return;
+
+      if (drag.moved) {
+        const target = squareAt(e.clientX, e.clientY);
+        if (target && validMovesRef.current.some(m => m.to.equals(target))) {
+          onDragMoveRef.current(drag.from, target);
+        }
+        justDraggedRef.current = true; // suppress the trailing synthetic click
+        window.setTimeout(() => { justDraggedRef.current = false; }, 350);
+        setDragVisual(null);
+        setHoverTarget(null);
+      }
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleUp);
+    return (): void => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleUp);
+    };
+  }, []);
+
+  const handlePointerDown = (position: Position, piece: Piece | null, e: React.PointerEvent): void => {
+    if (locked || !piece || piece.player !== currentPlayer) return;
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+
+    const pieceEl = (e.currentTarget as HTMLElement).querySelector('.game-piece');
+    const size = pieceEl ? pieceEl.getBoundingClientRect().width : 44;
+    dragRef.current = {
+      from: position,
+      startX: e.clientX,
+      startY: e.clientY,
+      moved: false,
+      visual: { color: piece.player === Player.RED ? 'red' : 'black', king: piece.isKing(), size }
+    };
+    // The ghost itself is only revealed once a real drag begins (see handleMove),
+    // so a plain tap never flashes one.
+  };
+
+  const handleClick = (position: Position): void => {
+    if (justDraggedRef.current) {
+      justDraggedRef.current = false;
+      return;
+    }
+    onSquareClick(position);
+  };
+
+  const squares = [];
   for (let row = 0; row < board.size; row++) {
     for (let col = 0; col < board.size; col++) {
       const position = new Position(row, col);
@@ -65,12 +193,6 @@ export function GameBoard({
       const moveDelta = movingEntry
         ? { dx: movingEntry.from.col - movingEntry.to.col, dy: movingEntry.from.row - movingEntry.to.row }
         : undefined;
-      const isCaptureBurst = animationState.capturedPieces.has(posKey);
-      const isPromoted = animationState.promotedPieces.has(posKey);
-
-      const isMustMove = showMoveHints && (mandatorySources?.has(posKey) ?? false);
-      const isHintFrom = hintMove?.from.equals(position) ?? false;
-      const isHintTo = hintMove?.to.equals(position) ?? false;
 
       squares.push(
         <GameSquare
@@ -83,12 +205,15 @@ export function GameBoard({
           isMoving={isMoving}
           moveDelta={moveDelta}
           isCaptured={false}
-          isCaptureBurst={isCaptureBurst}
-          isPromoted={isPromoted}
-          isMustMove={isMustMove}
-          isHintFrom={isHintFrom}
-          isHintTo={isHintTo}
-          onClick={() => onSquareClick(position)}
+          isCaptureBurst={animationState.capturedPieces.has(posKey)}
+          isPromoted={animationState.promotedPieces.has(posKey)}
+          isMustMove={showMoveHints && (mandatorySources?.has(posKey) ?? false)}
+          isHintFrom={hintMove?.from.equals(position) ?? false}
+          isHintTo={hintMove?.to.equals(position) ?? false}
+          isDragSource={dragVisual !== null && (dragRef.current?.from.equals(position) ?? false)}
+          isDropHover={hoverTarget?.equals(position) ?? false}
+          onClick={() => handleClick(position)}
+          onPointerDown={(e) => handlePointerDown(position, piece, e)}
         />
       );
     }
@@ -101,8 +226,20 @@ export function GameBoard({
   } as React.CSSProperties;
 
   return (
-    <div className="game-board" data-testid="game-board" style={boardStyle}>
+    <div className={`game-board${dragVisual ? ' dragging' : ''}`} data-testid="game-board" style={boardStyle}>
       {squares}
+      {dragVisual && (
+        <div
+          ref={ghostRef}
+          className="drag-ghost"
+          style={{ width: dragVisual.size, height: dragVisual.size }}
+          aria-hidden="true"
+        >
+          <div className={`game-piece ${dragVisual.color}${dragVisual.king ? ' king' : ''}`}>
+            {dragVisual.king && <span className="piece-crown">♛</span>}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/web/components/GameConfig.tsx
+++ b/src/ui/web/components/GameConfig.tsx
@@ -276,6 +276,15 @@ export function GameConfig({ onClose, onNewGame }: GameConfigProps): React.JSX.E
             />
             <span>Show move hints</span>
           </label>
+          <label className="config-checkbox">
+            <input
+              type="checkbox"
+              data-testid="sound-checkbox"
+              checked={config.sound}
+              onChange={(e) => updateConfig({ sound: e.target.checked })}
+            />
+            <span>Sound &amp; haptics</span>
+          </label>
         </div>
 
         <div className="config-actions">

--- a/src/ui/web/components/GamePiece.tsx
+++ b/src/ui/web/components/GamePiece.tsx
@@ -9,6 +9,7 @@ interface GamePieceProps {
   isMoving?: boolean;
   isCaptured?: boolean;
   isPromoted?: boolean;
+  isDragSource?: boolean;
   /** Cell offset (origin − destination) used to animate a glide into place. */
   moveDelta?: { dx: number; dy: number };
 }
@@ -19,10 +20,12 @@ export function GamePiece({
   isMoving,
   isCaptured,
   isPromoted,
+  isDragSource,
   moveDelta
 }: GamePieceProps): React.JSX.Element {
   const playerClass = piece.player === Player.RED ? 'red' : 'black';
   const kingClass = piece.isKing() ? 'king' : '';
+  const dragClass = isDragSource ? 'drag-source' : '';
 
   let animationClass = '';
   if (isCaptured) animationClass = 'capturing';
@@ -30,6 +33,9 @@ export function GamePiece({
   else if (isPromoted) animationClass = 'promoting';
 
   const playerName = piece.player === Player.RED ? 'red' : 'black';
+  const className = ['game-piece', playerClass, kingClass, animationClass, dragClass]
+    .filter(Boolean)
+    .join(' ');
 
   const style =
     isMoving && moveDelta
@@ -38,7 +44,7 @@ export function GamePiece({
 
   return (
     <div
-      className={`game-piece ${playerClass} ${kingClass} ${animationClass}`.trim()}
+      className={className}
       data-testid={`game-piece-${playerName}-${position.row}-${position.col}`}
       style={style}
       role="img"

--- a/src/ui/web/components/GameSquare.tsx
+++ b/src/ui/web/components/GameSquare.tsx
@@ -16,13 +16,13 @@ interface GameSquareProps {
   isMustMove?: boolean;
   isHintFrom?: boolean;
   isHintTo?: boolean;
-  /** Kind of move that lands here, used to vary the target affordance. */
   validMoveType?: MoveTargetType;
-  /** Show a capture burst (a piece was just taken from this square). */
   isCaptureBurst?: boolean;
-  /** Cell offset for a gliding piece. */
+  isDragSource?: boolean;
+  isDropHover?: boolean;
   moveDelta?: { dx: number; dy: number };
   onClick: () => void;
+  onPointerDown?: (e: React.PointerEvent) => void;
 }
 
 export function GameSquare({
@@ -38,8 +38,11 @@ export function GameSquare({
   isHintTo = false,
   validMoveType,
   isCaptureBurst = false,
+  isDragSource = false,
+  isDropHover = false,
   moveDelta,
-  onClick
+  onClick,
+  onPointerDown
 }: GameSquareProps): React.JSX.Element {
   const isDark = position.isDarkSquare();
 
@@ -50,12 +53,14 @@ export function GameSquare({
   if (isHintFrom) className += ' hint-from';
   if (isHintTo) className += ' hint-to';
   if (isCaptureBurst) className += ' capture-burst';
+  if (isDropHover) className += ' drop-hover';
 
   return (
     <div
       className={className}
       data-testid={`game-square-${position.row}-${position.col}`}
       onClick={onClick}
+      onPointerDown={onPointerDown}
     >
       {piece && (
         <GamePiece
@@ -64,6 +69,7 @@ export function GameSquare({
           isMoving={isMoving}
           isCaptured={isCaptured}
           isPromoted={isPromoted}
+          isDragSource={isDragSource}
           moveDelta={moveDelta}
         />
       )}

--- a/src/ui/web/components/GameStatus.tsx
+++ b/src/ui/web/components/GameStatus.tsx
@@ -15,21 +15,32 @@ export function GameStatus({
   moveCount 
 }: GameStatusProps): React.JSX.Element {
   const playerName = (player: Player): string => player === Player.RED ? 'Red' : 'Black';
-  const playerColorClass = currentPlayer === Player.RED ? 'red' : 'black';
+  const playerColorOf = (player: Player): string => (player === Player.RED ? 'red' : 'black');
+  const playerColorClass = playerColorOf(currentPlayer);
   
   return (
     <div className="game-status" data-testid="game-status">
       {gameOver ? (
-        <div className="game-over" data-testid="game-over-message">
+        <div
+          className={`game-over ${winner ? `winner-${playerColorOf(winner)}` : 'draw'}`}
+          data-testid="game-over-message"
+        >
           {winner ? (
-            `Game Over - ${playerName(winner)} Wins!`
+            <>
+              <span className="crown" aria-hidden="true">👑</span>
+              {playerName(winner)} wins!
+            </>
           ) : (
-            'Game Over - Draw!'
+            'It\'s a draw!'
           )}
         </div>
       ) : (
         <>
-          <div className={`current-player ${playerColorClass}`} data-testid="current-player">
+          <div
+            key={currentPlayer}
+            className={`current-player ${playerColorClass}`}
+            data-testid="current-player"
+          >
             Current Turn: {playerName(currentPlayer)}
           </div>
           <div className="move-count" data-testid="move-count">Move {moveCount + 1}</div>

--- a/src/ui/web/hooks/useConfigurableGame.ts
+++ b/src/ui/web/hooks/useConfigurableGame.ts
@@ -10,6 +10,7 @@ import { RuleEngine } from '../../../rules/RuleEngine';
 import { MinimaxAI } from '../../../ai/MinimaxAI';
 import { useGameConfig } from '../contexts/GameConfigContext';
 import { ANIMATION_DURATIONS, RuleSet, BoardSize, AiSide } from '../types/GameConfig';
+import { setSoundMuted, playMove, playCapture, playPromote, playWin, vibrate } from '../sound';
 
 /** How long the computer "thinks" before moving, so its move is visible. */
 const AI_THINK_DELAY_MS = 450;
@@ -102,9 +103,14 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
   // A suggested move highlighted by the Hint button (cleared on any change).
   const [hintMove, setHintMove] = useState<Move | null>(null);
 
+  // Keep the sound engine's mute flag in sync with the setting.
+  useEffect(() => {
+    setSoundMuted(!config.sound);
+  }, [config.sound]);
+
   // Update game instance when config changes
   useEffect(() => {
-    gameRef.current = new Game({ 
+    gameRef.current = new Game({
       ruleEngine: createRuleEngine(config.ruleSet, config.boardSize)
     });
     setSelectedPosition(null);
@@ -132,10 +138,19 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
     const observer: Partial<GameObserver> = {
       onMove: (move: Move) => {
         lastMoveRef.current = move;
+        if (move.captures.length > 0) {
+          playCapture();
+          vibrate([12, 18, 12]);
+        } else {
+          playMove();
+          vibrate(10);
+        }
         cachedStateRef.current = null; // Clear cache
         callback();
       },
       onGameEnd: () => {
+        playWin();
+        vibrate([40, 30, 40, 30, 80]);
         cachedStateRef.current = null; // Clear cache
         callback();
       },
@@ -153,6 +168,8 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
       },
       onPiecePromoted: (position: Position) => {
         lastPromotedRef.current = position;
+        playPromote();
+        vibrate([10, 40, 10]);
         cachedStateRef.current = null; // Clear cache
         callback();
       }

--- a/src/ui/web/hooks/useConfigurableGame.ts
+++ b/src/ui/web/hooks/useConfigurableGame.ts
@@ -38,7 +38,9 @@ interface CombinedGameState extends CoreGameState {
 }
 
 interface GameActions {
-  selectPosition: (position: Position) => void;
+  selectPosition: (position: Position, viaDrag?: boolean) => void;
+  /** Make the move from `from` to `to` directly (used by drag-and-drop). */
+  dragMove: (from: Position, to: Position) => void;
   undoMove: () => void;
   redoMove: () => void;
   newGame: (boardSize?: BoardSize, ruleSet?: RuleSet) => void;
@@ -81,6 +83,9 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
   }));
   const lastMoveRef = useRef<Move | null>(null);
   const lastPromotedRef = useRef<Position | null>(null);
+  // Set when a move is made by dragging, so the glide animation is skipped
+  // (the player already carried the piece to its destination).
+  const suppressGlideRef = useRef(false);
   
   // Use state for selection to properly trigger re-renders
   const [selectedPosition, setSelectedPosition] = useState<Position | null>(null);
@@ -194,14 +199,19 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
   useEffect(() => {
     if (lastMoveRef.current) {
       const move = lastMoveRef.current;
+      const skipGlide = suppressGlideRef.current;
+      suppressGlideRef.current = false;
+
       // Key by the destination: that is where the moved piece now lives, so the
       // glide animation (origin → destination) is applied to the right square.
-      const key = move.to.hash();
-
-      setAnimationState(prev => ({
-        ...prev,
-        movingPieces: new Map([[key, { from: move.from, to: move.to }]])
-      }));
+      // Skipped for drag-drops, where the piece is already at its destination.
+      if (!skipGlide) {
+        const key = move.to.hash();
+        setAnimationState(prev => ({
+          ...prev,
+          movingPieces: new Map([[key, { from: move.from, to: move.to }]])
+        }));
+      }
 
       // Handle captures
       if (move.captures.length > 0) {
@@ -291,7 +301,7 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
     setThinking,
   ]);
 
-  const selectPosition = useCallback((position: Position): void => {
+  const selectPosition = useCallback((position: Position, viaDrag = false): void => {
     const game = gameRef.current;
     if (game.isGameOver()) return;
 
@@ -312,6 +322,7 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
       const move = validMoves.find(m => m.to.equals(position));
       if (move) {
         try {
+          suppressGlideRef.current = viaDrag; // skip the glide for drag-drops
           game.makeMove(move);
           setSelectedPosition(null);
           setValidMoves([]);
@@ -326,6 +337,29 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
       }
     }
   }, [selectedPosition, validMoves, config.mode, config.aiSide]);
+
+  const dragMove = useCallback((from: Position, to: Position): void => {
+    const game = gameRef.current;
+    if (game.isGameOver() || isThinkingRef.current) return;
+    if (config.mode === 'ai' && game.getCurrentPlayer() === aiPlayerFor(config.aiSide)) return;
+
+    const piece = game.getBoard().getPiece(from);
+    if (!piece || piece.player !== game.getCurrentPlayer()) return;
+
+    const move = game.getPossibleMoves(from).find(m => m.to.equals(to));
+    if (!move) return;
+
+    try {
+      suppressGlideRef.current = true; // the player already carried it there
+      game.makeMove(move);
+      setSelectedPosition(null);
+      setValidMoves([]);
+      setErrorMessage(null);
+      setHintMove(null);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    }
+  }, [config.mode, config.aiSide]);
 
   const newGame = useCallback((boardSize?: BoardSize, ruleSet?: RuleSet): void => {
     const rules = ruleSet || config.ruleSet;
@@ -402,7 +436,7 @@ export function useConfigurableGame(): UseConfigurableGameReturn {
 
   return {
     gameState: combinedGameState,
-    actions: { selectPosition, undoMove, redoMove, newGame, showHint },
+    actions: { selectPosition, dragMove, undoMove, redoMove, newGame, showHint },
     canUndo: gameState.moveHistory.length > 0,
     canRedo: gameRef.current.canRedo(),
     isThinking,

--- a/src/ui/web/sound.ts
+++ b/src/ui/web/sound.ts
@@ -1,0 +1,127 @@
+/**
+ * A tiny synthesized sound engine for the game — no audio files, just the Web
+ * Audio API. Every entry point is guarded so it is a no-op where Web Audio is
+ * unavailable (e.g. jsdom in tests) and respects a global mute flag.
+ *
+ * The AudioContext is created lazily on first use, which is always triggered by
+ * a user gesture (a move), satisfying browser autoplay policies.
+ */
+
+type WindowWithAudio = Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext };
+
+let ctx: AudioContext | null = null;
+let master: GainNode | null = null;
+let muted = false;
+
+export function setSoundMuted(value: boolean): void {
+  muted = value;
+}
+
+function audio(): { ctx: AudioContext; master: GainNode } | null {
+  if (muted || typeof window === 'undefined') return null;
+  const Ctor = window.AudioContext ?? (window as WindowWithAudio).webkitAudioContext;
+  if (!Ctor) return null;
+  if (!ctx) {
+    ctx = new Ctor();
+    master = ctx.createGain();
+    master.gain.value = 0.5;
+    master.connect(ctx.destination);
+  }
+  if (ctx.state === 'suspended') {
+    void ctx.resume();
+  }
+  return master ? { ctx, master } : null;
+}
+
+interface ToneOpts {
+  freq: number;
+  dur: number;
+  type?: OscillatorType;
+  gain?: number;
+  delay?: number;
+  glideTo?: number;
+}
+
+function tone({ freq, dur, type = 'sine', gain = 0.2, delay = 0, glideTo }: ToneOpts): void {
+  const a = audio();
+  if (!a) return;
+  const t0 = a.ctx.currentTime + delay;
+  const osc = a.ctx.createOscillator();
+  const g = a.ctx.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, t0);
+  if (glideTo) osc.frequency.exponentialRampToValueAtTime(glideTo, t0 + dur);
+  // quick attack, smooth exponential decay — feels percussive and soft
+  g.gain.setValueAtTime(0.0001, t0);
+  g.gain.exponentialRampToValueAtTime(gain, t0 + 0.008);
+  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  osc.connect(g);
+  g.connect(a.master);
+  osc.start(t0);
+  osc.stop(t0 + dur + 0.02);
+}
+
+/** A short filtered-noise burst for woody "clack" transients. */
+function noise(dur: number, gain: number, delay = 0): void {
+  const a = audio();
+  if (!a) return;
+  const t0 = a.ctx.currentTime + delay;
+  const frames = Math.floor(a.ctx.sampleRate * dur);
+  const buffer = a.ctx.createBuffer(1, frames, a.ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < frames; i++) {
+    data[i] = (Math.random() * 2 - 1) * (1 - i / frames); // decaying noise
+  }
+  const src = a.ctx.createBufferSource();
+  src.buffer = buffer;
+  const filter = a.ctx.createBiquadFilter();
+  filter.type = 'bandpass';
+  filter.frequency.value = 1600;
+  const g = a.ctx.createGain();
+  g.gain.value = gain;
+  src.connect(filter);
+  filter.connect(g);
+  g.connect(a.master);
+  src.start(t0);
+}
+
+/** Soft wooden "tock" when a piece is placed. */
+export function playMove(): void {
+  tone({ freq: 210, dur: 0.16, type: 'triangle', gain: 0.18 });
+  tone({ freq: 140, dur: 0.12, type: 'sine', gain: 0.12 });
+}
+
+/** A sharper "clack" plus a low thump when a piece is captured. */
+export function playCapture(): void {
+  noise(0.09, 0.3);
+  tone({ freq: 120, dur: 0.18, type: 'sine', gain: 0.22 });
+  tone({ freq: 320, dur: 0.1, type: 'triangle', gain: 0.12 });
+}
+
+/** A bright rising chime when a piece is crowned. */
+export function playPromote(): void {
+  tone({ freq: 523.25, dur: 0.18, type: 'sine', gain: 0.16 }); // C5
+  tone({ freq: 659.25, dur: 0.18, type: 'sine', gain: 0.16, delay: 0.09 }); // E5
+  tone({ freq: 783.99, dur: 0.28, type: 'sine', gain: 0.18, delay: 0.18 }); // G5
+}
+
+/** A short triumphant arpeggio when the game is won. */
+export function playWin(): void {
+  const notes = [523.25, 659.25, 783.99, 1046.5];
+  notes.forEach((f, i) => tone({ freq: f, dur: 0.34, type: 'triangle', gain: 0.18, delay: i * 0.11 }));
+}
+
+/** A subtle tick when a piece is picked up. */
+export function playPickup(): void {
+  tone({ freq: 440, dur: 0.05, type: 'sine', gain: 0.08 });
+}
+
+/** Light haptic feedback on supporting (touch) devices. */
+export function vibrate(pattern: number | number[]): void {
+  if (muted || typeof navigator === 'undefined' || typeof navigator.vibrate !== 'function') return;
+  try {
+    navigator.vibrate(pattern);
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/ui/web/styles.css
+++ b/src/ui/web/styles.css
@@ -619,9 +619,10 @@ body::before {
   animation: chipIn 0.3s var(--ease-spring);
 }
 
-/* Round icon buttons (settings / help) */
+/* Round icon buttons (settings / help / sound) */
 .settings-btn,
-.help-btn {
+.help-btn,
+.sound-btn {
   position: absolute;
   top: 22px;
   width: 42px;
@@ -640,8 +641,10 @@ body::before {
 }
 .settings-btn { right: 22px; }
 .help-btn { right: 72px; }
+.sound-btn { right: 122px; }
 .settings-btn:hover,
-.help-btn:hover { transform: translateY(-2px) rotate(-4deg); box-shadow: 0 8px 16px -8px rgba(40, 22, 8, 0.55); }
+.help-btn:hover,
+.sound-btn:hover { transform: translateY(-2px) rotate(-4deg); box-shadow: 0 8px 16px -8px rgba(40, 22, 8, 0.55); }
 
 /* ── Overlays: settings & help ──────────────────────────────────────────── */
 

--- a/src/ui/web/styles.css
+++ b/src/ui/web/styles.css
@@ -453,6 +453,53 @@ body::before {
   50% { box-shadow: 0 0 22px 6px rgba(233, 200, 105, 0.85); }
 }
 
+/* ── Drag & drop ────────────────────────────────────────────────────────── */
+
+/* Prevent the page from scrolling/selecting while dragging a piece. */
+.game-board {
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* The piece left behind at the origin fades while it is being carried. */
+.game-piece.drag-source {
+  opacity: 0.22;
+  filter: none;
+}
+
+/* The lifted piece that follows the pointer. */
+.drag-ghost {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 1000;
+  pointer-events: none;
+  border-radius: 50%;
+  filter: drop-shadow(0 18px 16px rgba(20, 10, 4, 0.55));
+}
+.drag-ghost .game-piece {
+  width: 100%;
+  height: 100%;
+  cursor: grabbing;
+  animation: ghostPop 0.16s var(--ease-spring) both;
+}
+@keyframes ghostPop {
+  from { transform: scale(0.86); }
+  to { transform: scale(1.12); }
+}
+
+/* The valid target currently under the pointer gets a strong drop ring. */
+.game-square.drop-hover::after {
+  content: '';
+  position: absolute;
+  inset: 6%;
+  border-radius: 12px;
+  box-shadow: 0 0 0 4px var(--gold-bright), 0 0 22px 4px rgba(233, 200, 105, 0.6);
+  z-index: 5;
+  pointer-events: none;
+}
+
 /* ── Status ─────────────────────────────────────────────────────────────── */
 
 .game-status {

--- a/src/ui/web/styles.css
+++ b/src/ui/web/styles.css
@@ -522,6 +522,13 @@ body::before {
   align-items: center;
   justify-content: center;
   gap: 12px;
+  animation: turnIn 0.42s var(--ease-spring) both;
+}
+
+/* Replayed each turn because the element is keyed by the current player. */
+@keyframes turnIn {
+  from { opacity: 0; transform: translateY(-6px) scale(0.96); }
+  to { opacity: 1; transform: none; }
 }
 
 .current-player::before {
@@ -550,13 +557,28 @@ body::before {
 .game-over {
   font-family: var(--font-display);
   color: var(--ink);
-  font-size: 1.7rem;
+  font-size: 1.8rem;
   font-weight: 700;
-  animation: gameOverIn 0.5s var(--ease-spring) both;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  animation: gameOverIn 0.6s var(--ease-spring) both;
+}
+.game-over.winner-red { color: var(--cherry); text-shadow: 0 2px 10px rgba(195, 60, 46, 0.3); }
+.game-over.winner-black { color: var(--ink); text-shadow: 0 2px 10px rgba(40, 22, 8, 0.25); }
+.game-over .crown {
+  display: inline-block;
+  animation: crownBounce 1.1s var(--ease-spring) infinite;
 }
 @keyframes gameOverIn {
-  from { opacity: 0; transform: scale(0.8); }
+  from { opacity: 0; transform: scale(0.7); }
+  60% { transform: scale(1.08); }
   to { opacity: 1; transform: scale(1); }
+}
+@keyframes crownBounce {
+  0%, 100% { transform: translateY(0) rotate(-6deg); }
+  50% { transform: translateY(-6px) rotate(6deg); }
 }
 
 /* ── Announcements (thinking / must-jump) ──────────────────────────────────*/
@@ -861,6 +883,31 @@ body::before {
   .game-board { width: min(92vw, 460px); padding: 11px; }
   .config-panel, .help-panel { border-radius: 0; max-width: 100%; max-height: 100vh; }
   .help-btn { right: 70px; }
+}
+
+/* ── Win celebration confetti ──────────────────────────────────────────────*/
+
+.confetti {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 2000;
+}
+.confetti-bit {
+  position: absolute;
+  top: -12%;
+  border-radius: 2px;
+  opacity: 0;
+  will-change: transform, opacity;
+  animation-name: confettiFall;
+  animation-timing-function: cubic-bezier(0.2, 0.6, 0.4, 1);
+  animation-fill-mode: forwards;
+}
+@keyframes confettiFall {
+  0% { transform: translateY(-12vh) translateX(0) rotate(0); opacity: 0; }
+  8% { opacity: 1; }
+  100% { transform: translateY(112vh) translateX(var(--drift, 0)) rotate(var(--spin, 720deg)); opacity: 0; }
 }
 
 /* ── Accessibility: respect reduced motion ─────────────────────────────────*/

--- a/src/ui/web/types/GameConfig.ts
+++ b/src/ui/web/types/GameConfig.ts
@@ -16,6 +16,8 @@ export interface GameConfig {
   aiSide: AiSide;
   /** Computer difficulty when mode is 'ai'. */
   difficulty: Difficulty;
+  /** Sound effects + haptics on/off. */
+  sound: boolean;
 }
 
 export const defaultConfig: GameConfig = {
@@ -26,7 +28,8 @@ export const defaultConfig: GameConfig = {
   showMoveHints: true,
   mode: 'human',
   aiSide: 'black',
-  difficulty: 'easy'
+  difficulty: 'easy',
+  sound: true
 };
 
 export const ANIMATION_DURATIONS = {

--- a/tests/integration/CaptureAndControls.test.tsx
+++ b/tests/integration/CaptureAndControls.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GameApp } from '../../src/ui/web/GameApp';
+
+function clickSquare(row: number, col: number): void {
+  fireEvent.click(screen.getByTestId(`game-square-${row}-${col}`));
+}
+
+describe('captures and controls', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('captures an opponent piece through the UI and flags the mandatory jump', () => {
+    render(<GameApp />);
+
+    clickSquare(5, 2); // select red
+    clickSquare(4, 3); // red advances
+    clickSquare(2, 5); // select black
+    clickSquare(3, 4); // black advances next to the red piece
+
+    // A capture is now forced for Red.
+    expect(screen.getByTestId('capture-alert')).toBeInTheDocument();
+
+    clickSquare(4, 3); // select the forced piece
+    clickSquare(2, 5); // jump → captures the black piece at (3,4)
+
+    expect(document.querySelector('[data-testid="game-square-3-4"] .game-piece')).toBeNull();
+    expect(document.querySelector('[data-testid="game-square-2-5"] .game-piece.red')).not.toBeNull();
+  });
+
+  it('toggles sound from the header button', () => {
+    render(<GameApp />);
+    const button = screen.getByTestId('sound-button');
+    expect(button).toHaveTextContent('🔊');
+    fireEvent.click(button);
+    expect(button).toHaveTextContent('🔇');
+    expect(button).toHaveAttribute('aria-label', 'Unmute sound');
+  });
+});

--- a/tests/integration/DragAndDrop.test.tsx
+++ b/tests/integration/DragAndDrop.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { GameApp } from '../../src/ui/web/GameApp';
+
+type WithFromPoint = { elementFromPoint?: (x: number, y: number) => Element | null };
+
+/** Dispatch a window-level pointer event with coordinates (jsdom has no layout,
+ *  so the board's elementFromPoint lookups are mocked in the test). */
+function emitWindow(type: string, x: number, y: number): void {
+  const ev = new Event(type, { bubbles: true });
+  Object.assign(ev, { clientX: x, clientY: y, pointerId: 1, pointerType: 'mouse', button: 0 });
+  act(() => {
+    window.dispatchEvent(ev);
+  });
+}
+
+function mockDropPoint(el: Element | null): void {
+  (document as unknown as WithFromPoint).elementFromPoint = (): Element | null => el;
+}
+
+describe('drag and drop', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => {
+    delete (document as unknown as WithFromPoint).elementFromPoint;
+    localStorage.clear();
+  });
+
+  it('moves a piece when it is dragged onto a valid square', () => {
+    render(<GameApp />);
+    const source = screen.getByTestId('game-square-5-0');
+    const target = screen.getByTestId('game-square-4-1');
+    mockDropPoint(target);
+
+    fireEvent.pointerDown(source, { clientX: 10, clientY: 10, button: 0, pointerType: 'mouse' });
+    emitWindow('pointermove', 40, 40);   // crosses the drag threshold → selects + lifts
+    emitWindow('pointermove', 120, 120); // keep dragging
+    emitWindow('pointerup', 120, 120);   // drop on the target
+
+    expect(document.querySelector('[data-testid="game-square-4-1"] .game-piece.red')).not.toBeNull();
+    expect(document.querySelector('[data-testid="game-square-5-0"] .game-piece')).toBeNull();
+  });
+
+  it('does not move when released off any valid square', () => {
+    render(<GameApp />);
+    const source = screen.getByTestId('game-square-5-0');
+    mockDropPoint(null);
+
+    fireEvent.pointerDown(source, { clientX: 10, clientY: 10, button: 0, pointerType: 'mouse' });
+    emitWindow('pointermove', 60, 60);
+    emitWindow('pointerup', 300, 300);
+
+    expect(document.querySelector('[data-testid="game-square-5-0"] .game-piece.red')).not.toBeNull();
+    expect(screen.getByText('Move 1')).toBeInTheDocument();
+  });
+});

--- a/tests/ui/Celebration.test.tsx
+++ b/tests/ui/Celebration.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { GameStatus } from '../../src/ui/web/components/GameStatus';
+import { Confetti } from '../../src/ui/web/components/Confetti';
+import { Player } from '../../src/types';
+
+describe('Win celebration', () => {
+  it('shows a crowned winner message on game over', () => {
+    render(<GameStatus currentPlayer={Player.RED} gameOver={true} winner={Player.RED} moveCount={20} />);
+    const msg = screen.getByTestId('game-over-message');
+    expect(msg).toHaveTextContent('Red wins!');
+    expect(msg).toHaveClass('winner-red');
+    expect(msg.querySelector('.crown')).not.toBeNull();
+  });
+
+  it('shows a draw message when there is no winner', () => {
+    render(<GameStatus currentPlayer={Player.BLACK} gameOver={true} winner={null} moveCount={40} />);
+    expect(screen.getByTestId('game-over-message')).toHaveTextContent('It\'s a draw!');
+  });
+
+  it('renders the current turn (not a game-over message) during play', () => {
+    render(<GameStatus currentPlayer={Player.BLACK} gameOver={false} winner={null} moveCount={3} />);
+    expect(screen.getByTestId('current-player')).toHaveTextContent('Current Turn: Black');
+    expect(screen.queryByTestId('game-over-message')).not.toBeInTheDocument();
+  });
+
+  it('Confetti renders the requested number of pieces', () => {
+    const { container } = render(<Confetti count={30} />);
+    expect(container.querySelectorAll('.confetti-bit')).toHaveLength(30);
+  });
+});

--- a/tests/ui/sound.test.ts
+++ b/tests/ui/sound.test.ts
@@ -1,0 +1,112 @@
+import {
+  setSoundMuted,
+  playMove,
+  playCapture,
+  playPromote,
+  playWin,
+  playPickup,
+  vibrate
+} from '../../src/ui/web/sound';
+
+/** Minimal Web Audio stubs so the synthesis code paths actually run in jsdom. */
+class FakeParam {
+  setValueAtTime(): void {}
+  exponentialRampToValueAtTime(): void {}
+}
+class FakeNode {
+  connect(): void {}
+}
+class FakeGain extends FakeNode {
+  gain = new FakeParam();
+}
+class FakeOsc extends FakeNode {
+  type = 'sine';
+  frequency = new FakeParam();
+  start = jest.fn();
+  stop = jest.fn();
+}
+class FakeBufferSource extends FakeNode {
+  buffer: unknown = null;
+  start = jest.fn();
+}
+class FakeFilter extends FakeNode {
+  type = 'bandpass';
+  frequency = { value: 0 };
+}
+
+const createOscillator = jest.fn(() => new FakeOsc());
+
+class FakeAudioContext {
+  static ctorCount = 0;
+  currentTime = 0;
+  sampleRate = 44100;
+  destination = {};
+  state: AudioContextState = 'running';
+  constructor() {
+    FakeAudioContext.ctorCount++;
+  }
+  createGain = (): FakeGain => new FakeGain();
+  createOscillator = createOscillator;
+  createBuffer = (_c: number, frames: number): { getChannelData: () => Float32Array } => ({
+    getChannelData: () => new Float32Array(frames)
+  });
+  createBufferSource = (): FakeBufferSource => new FakeBufferSource();
+  createBiquadFilter = (): FakeFilter => new FakeFilter();
+  resume = jest.fn();
+}
+
+describe('sound engine', () => {
+  afterEach(() => {
+    setSoundMuted(false);
+    createOscillator.mockClear();
+  });
+
+  it('is a no-op when no AudioContext is available (must run before one is created)', () => {
+    const win = window as unknown as { AudioContext?: unknown; webkitAudioContext?: unknown };
+    const saved = win.AudioContext;
+    delete win.AudioContext;
+    delete win.webkitAudioContext;
+    setSoundMuted(false);
+    expect(() => {
+      playMove();
+      playCapture();
+    }).not.toThrow();
+    expect(createOscillator).not.toHaveBeenCalled();
+    win.AudioContext = saved;
+  });
+
+  it('synthesizes every cue without throwing when audio is available', () => {
+    (window as unknown as { AudioContext: unknown }).AudioContext = FakeAudioContext;
+    setSoundMuted(false);
+    expect(() => {
+      playMove();
+      playCapture();
+      playPromote();
+      playWin();
+      playPickup();
+    }).not.toThrow();
+    expect(createOscillator).toHaveBeenCalled();
+  });
+
+  it('stays silent when muted', () => {
+    (window as unknown as { AudioContext: unknown }).AudioContext = FakeAudioContext;
+    setSoundMuted(true);
+    playMove();
+    playCapture();
+    expect(createOscillator).not.toHaveBeenCalled();
+  });
+
+  it('triggers haptics only when unmuted and supported', () => {
+    const vib = jest.fn();
+    Object.defineProperty(navigator, 'vibrate', { value: vib, configurable: true });
+
+    setSoundMuted(false);
+    vibrate([10, 20]);
+    expect(vib).toHaveBeenCalledWith([10, 20]);
+
+    vib.mockClear();
+    setSoundMuted(true);
+    vibrate(10);
+    expect(vib).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The "next layer" of polish — making the game feel alive. Three cohesive additions, each verified.

## 🎯 Drag-and-drop
Press and drag a piece: a lifted ghost follows the pointer, the origin dims, valid landings glow, and the square under the pointer shows a strong drop ring. Release on a valid square to move; release elsewhere snaps back. **Tap-to-move still works** for everyone (and is what the jsdom tests use). Built with always-on window pointer listeners reading refs (no stale closures), a tap/drag threshold, synthetic-click suppression, and a self-contained `dragMove` action. Drag-drops skip the glide (the piece is already there) and `touch-action: none` prevents page scroll mid-drag.

## 🔊 Sound + haptics
A guarded, asset-free Web Audio engine: a wooden "tock" on a move, a "clack" + thump on a capture, a rising chime on promotion, a triumphant arpeggio on a win — with matching `navigator.vibrate` haptics. Lazy AudioContext, a header mute toggle (🔊/🔇) and a Settings checkbox, and no-ops where Web Audio is absent (so tests are unaffected).

## 🎉 Juice
A confetti burst + a crowned, color-tinted winner banner on a win; a re-animating turn-handoff cue each turn; capture bursts and a promotion flourish.

## Verification
- Live in a real browser: drag `(5,0)→(4,1)` moved the piece with no double-action; 0 console errors.
- New tests: sound synthesis (mocked AudioContext) + mute + haptics; a real pointer-drag move and an off-board release; a UI capture with the forced-jump flag; the sound toggle; and the crowned winner / draw / confetti rendering.
- Full gate green: lint, typecheck, node + web builds, **343 tests**, 80% coverage gate met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)