### PR TITLE
a11y fixes + verification: contrast, viewport zoom, dialog semantics, drag-edge tests

### DIFF
--- a/src/ui/web/components/GameConfig.tsx
+++ b/src/ui/web/components/GameConfig.tsx
@@ -49,7 +49,7 @@ export function GameConfig({ onClose, onNewGame }: GameConfigProps): React.JSX.E
 
   return (
     <div className="config-overlay" data-testid="game-config">
-      <div className="config-panel">
+      <div className="config-panel" role="dialog" aria-modal="true" aria-label="Game Settings">
         <div className="config-header">
           <h2>Game Settings</h2>
           <button className="close-btn" data-testid="config-close-button" onClick={onClose}>×</button>

--- a/src/ui/web/components/HelpPanel.tsx
+++ b/src/ui/web/components/HelpPanel.tsx
@@ -34,7 +34,7 @@ export function HelpPanel({ ruleSet, onClose }: HelpPanelProps): React.JSX.Eleme
 
   return (
     <div className="help-overlay" data-testid="help-panel">
-      <div className="help-panel">
+      <div className="help-panel" role="dialog" aria-modal="true" aria-label="How to Play">
         <div className="help-header">
           <h2>How to Play</h2>
           <button className="close-btn" data-testid="help-close-button" onClick={onClose} aria-label="Close help">×</button>

--- a/src/ui/web/index.html
+++ b/src/ui/web/index.html
@@ -2,10 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Play and learn checkers — including Jump Your Own Man rules — against a friend or the computer." />
     <meta name="theme-color" content="#3a2417" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />

--- a/src/ui/web/styles.css
+++ b/src/ui/web/styles.css
@@ -13,8 +13,9 @@
   --surface-2: #f4ead7;
   --surface-line: #e6d8bf;
   --ink: #3b2a1b;
-  --ink-soft: #8a7560;
-  --ink-faint: #b6a48c;
+  /* Muted inks kept dark enough for WCAG AA (>=4.5:1) on the cream surfaces. */
+  --ink-soft: #6a5946;
+  --ink-faint: #6f5d49;
 
   /* Table / felt atmosphere */
   --felt-1: #4a2f1c;
@@ -693,9 +694,9 @@ body::before {
 .help-btn,
 .sound-btn {
   position: absolute;
-  top: 22px;
-  width: 42px;
-  height: 42px;
+  top: 20px;
+  width: 44px;
+  height: 44px;
   border-radius: 13px;
   background: linear-gradient(180deg, #fff, var(--surface-2));
   border: 1px solid var(--surface-line);
@@ -867,8 +868,9 @@ body::before {
   --surface-2: #1a2029;
   --surface-line: #333d49;
   --ink: #eef2f7;
-  --ink-soft: #9aa6b3;
-  --ink-faint: #66727f;
+  /* Light enough on the dark surfaces to clear WCAG AA. */
+  --ink-soft: #b3bdc8;
+  --ink-faint: #a4afba;
   --felt-1: #161b22;
   --felt-2: #0b0e13;
   --frame-1: #2a323d;

--- a/tests/integration/DragAndDrop.test.tsx
+++ b/tests/integration/DragAndDrop.test.tsx
@@ -51,4 +51,33 @@ describe('drag and drop', () => {
     expect(document.querySelector('[data-testid="game-square-5-0"] .game-piece.red')).not.toBeNull();
     expect(screen.getByText('Move 1')).toBeInTheDocument();
   });
+
+  it('ignores attempts to drag the opponent\'s piece', () => {
+    render(<GameApp />);
+    const black = screen.getByTestId('game-square-2-1'); // black piece, not Red's turn
+    mockDropPoint(screen.getByTestId('game-square-3-2'));
+
+    fireEvent.pointerDown(black, { clientX: 10, clientY: 10, button: 0, pointerType: 'mouse' });
+    emitWindow('pointermove', 60, 60);
+    emitWindow('pointerup', 60, 60);
+
+    // Nothing happened: still Red to move, black piece untouched.
+    expect(screen.getByText('Move 1')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="game-square-2-1"] .game-piece.black')).not.toBeNull();
+  });
+
+  it('can be undone after a drag move', () => {
+    render(<GameApp />);
+    const source = screen.getByTestId('game-square-5-0');
+    mockDropPoint(screen.getByTestId('game-square-4-1'));
+
+    fireEvent.pointerDown(source, { clientX: 10, clientY: 10, button: 0, pointerType: 'mouse' });
+    emitWindow('pointermove', 60, 60);
+    emitWindow('pointerup', 120, 120);
+    expect(screen.getByText('Move 2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('undo-button'));
+    expect(screen.getByText('Move 1')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="game-square-5-0"] .game-piece.red')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
Ran the previously-unused verification surfaces (Playwright accessibility suite + targeted real-browser checks) and fixed the regressions found.

## Regressions fixed (introduced by the visual redesign)
- **Color contrast (WCAG AA)**: muted inks were below 4.5:1 on the cream surfaces (e.g. 4.04:1). Darkened on light themes, lightened on dark. Verified **0 axe violations** on main, settings, and dark theme.
- **Viewport zoom disabled**: the meta tag had `maximum-scale=1.0, user-scalable=no` (axe-critical — blocks pinch-zoom). Removed.

## Quick pre-existing a11y wins
- Settings + Help modals expose `role="dialog"` + `aria-modal` + `aria-label`.
- Icon buttons are now 44×44 (touch-target guidance).

## Verified working in real Chromium (not regressions)
- Click-to-select, move, capture; drag-and-drop; **all four variant boards render** (International = 100 squares / 20+20 pieces).

## New durable tests (Jest)
- Dragging an opponent's piece is ignored; a drag move can be undone.

## Known remaining gaps (pre-existing, documented for follow-up)
- Board squares aren't keyboard-operable (non-focusable divs) → no keyboard play.
- Modals lack a focus trap.
- The Playwright E2E suite is unmaintained/aspirational (stale GamePage assumptions) and needs Firefox/WebKit installs; the maintained suite is Jest (345 green).

Full gate: lint, typecheck, web build, 345 Jest tests, 80% coverage gate met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)