### PR TITLE
feat: GitHub Pages deployment (env-configurable base)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Auto-deploy whenever main updates (main is PR-gated by ci.yml).
+  push:
+    branches: [main]
+  # Allow manual deploys from the Actions tab.
+  workflow_dispatch:
+
+# Least-privilege token plus the OIDC/Pages permissions the deploy needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never run two Pages deploys at once; let an in-flight deploy finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (Pages base)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for the project-page subpath
+        # Serve from /<repo>/ (e.g. /checkers/). For a user/org site or a custom
+        # domain served at the root, change this to PAGES_BASE=/.
+        env:
+          PAGES_BASE: /${{ github.event.repository.name }}/
+        run: npm run build:web
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/web
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -29,6 +29,21 @@ full‑screen like a normal app — handy for playing with a kid.
 
 The production build is the contents of `dist/web/`. Point any static host at it.
 
+### GitHub Pages (automated)
+`.github/workflows/deploy-pages.yml` builds and publishes on every push to
+`main`. **One-time setup:** in the repo, go to **Settings → Pages → Build and
+deployment → Source = "GitHub Actions"** (until this is set the deploy job
+fails). The site then publishes to `https://<user>.github.io/<repo>/` — for this
+repo, `https://davidleathers113.github.io/checkers/`.
+
+The workflow builds with `PAGES_BASE=/<repo>/`, which sets Vite's base path so
+all assets, the manifest/icon links, and the service worker resolve under the
+sub-path (offline support included). Run a deploy on demand from the **Actions**
+tab via "Run workflow".
+
+For a **user/org site or a custom domain served at the root**, change the
+workflow's `PAGES_BASE` to `/` (or remove it).
+
 ### Render (blueprint included)
 `render.yaml` is committed. On https://render.com choose **New → Blueprint**,
 connect this repo, and Render will build with `npm ci && npm run build:web` and
@@ -46,14 +61,18 @@ publish `dist/web/`. Or, with the Render CLI: `render blueprint launch`.
 ### Any static host / S3 / nginx
 Upload the contents of `dist/web/` and serve `index.html`.
 
-## Note on sub‑path hosting (e.g. GitHub Pages project sites)
+## Note on sub‑path hosting
 
-The app is built for the site root (`/`). If you must host it under a sub‑path
-like `https://user.github.io/checkers/`, set Vite's base URL when building:
+The build defaults to the site root (`/`), which suits Render, Netlify, Vercel,
+and custom domains with no change. To host under a sub‑path (e.g. a GitHub Pages
+project site at `https://user.github.io/checkers/`), set the base when building:
 
 ```bash
-# vite.config.ts: add `base: '/checkers/'`, then
-npm run build:web
+PAGES_BASE=/checkers/ npm run build:web
+# preview it under the sub-path:
+PAGES_BASE=/checkers/ npm run preview   # http://localhost:4173/checkers/
 ```
 
-Root‑hosted deploys (Render, Netlify, Vercel, a custom domain) need no change.
+The GitHub Pages workflow above does this automatically. `PAGES_BASE` feeds
+Vite's `base`, the `%BASE_URL%` links in `index.html`, and the service-worker
+registration URL, so everything resolves correctly under the sub-path.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,7 +47,8 @@ export default [
       },
       globals: {
         ...globals.browser,
-        __PROD__: 'readonly'
+        __PROD__: 'readonly',
+        __BASE__: 'readonly'
       }
     },
     plugins: {

--- a/src/ui/web/index.html
+++ b/src/ui/web/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Play and learn checkers — including Jump Your Own Man rules — against a friend or the computer." />
     <meta name="theme-color" content="#3a2417" />
-    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
-    <link rel="apple-touch-icon" href="/icon.svg" />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%icon.svg" />
+    <link rel="apple-touch-icon" href="%BASE_URL%icon.svg" />
+    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Checkers" />

--- a/src/ui/web/main.tsx
+++ b/src/ui/web/main.tsx
@@ -15,7 +15,7 @@ root.render(<GameApp />);
 // support is a progressive enhancement, so failures are non-fatal.
 if (__PROD__ && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => {
+    navigator.serviceWorker.register(`${__BASE__}sw.js`).catch(() => {
       /* Ignore: the game still works fully online without a service worker. */
     });
   });

--- a/src/ui/web/vite-env.d.ts
+++ b/src/ui/web/vite-env.d.ts
@@ -1,5 +1,8 @@
 /// <reference types="vite/client" />
 
-// Compile-time constant injected by Vite's `define` (see vite.config.ts).
-// True only in production builds; used to gate service-worker registration.
+// Compile-time constants injected by Vite's `define` (see vite.config.ts).
+// __PROD__ is true only in production builds (gates service-worker registration);
+// __BASE__ is the public base path (e.g. '/' or '/checkers/'), used to build the
+// service-worker URL so it resolves correctly under a subpath deployment.
 declare const __PROD__: boolean;
+declare const __BASE__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,24 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// `__PROD__` is a compile-time constant (true only for `vite build`). It lets
-// app code gate production-only behaviour — e.g. service-worker registration —
-// without `import.meta.env`, which the project's CommonJS `tsc` config can't parse.
+// Public base path. Defaults to '/' (root) for local dev/preview, the Playwright
+// E2E build, and the Render deployment. The GitHub Pages workflow sets
+// PAGES_BASE=/<repo>/ so the same code also serves correctly from a project-page
+// subpath (e.g. /checkers/). Leaving PAGES_BASE unset reproduces today's output
+// exactly.
+const base = process.env['PAGES_BASE'] ?? '/';
+
+// Compile-time constants exposed to app code (the project's CommonJS `tsc`
+// config can't parse `import.meta.env`, so we inject these via `define`):
+//   __PROD__ — true only for `vite build` (gates service-worker registration)
+//   __BASE__ — the resolved public base path (used to register the SW)
 export default defineConfig(({ command }) => ({
   plugins: [react()],
   root: 'src/ui/web',
+  base,
   define: {
     __PROD__: JSON.stringify(command === 'build'),
+    __BASE__: JSON.stringify(base),
   },
   build: {
     outDir: '../../../dist/web',


### PR DESCRIPTION
## Summary

Makes the game deployable to **GitHub Pages** (project page at a subpath) without disturbing the existing root deployments (Render, local, E2E). A single `PAGES_BASE` env var drives Vite's `base`; when unset it's `/`, so all current output is byte-identical.

## Changes
- **`vite.config.ts`** — `base` from `PAGES_BASE` (default `/`); expose it to app code as a `__BASE__` `define`.
- **`main.tsx`** — register the service worker at `${__BASE__}sw.js` so it resolves (and scopes) under the subpath.
- **`index.html`** — icon + manifest links use Vite's `%BASE_URL%` placeholder. `vite-env.d.ts`/`eslint` declare `__BASE__`.
- **`public/.nojekyll`** — skip Jekyll on Pages.
- **`.github/workflows/deploy-pages.yml`** — build with `PAGES_BASE=/<repo>/` and deploy on push to `main` (+ manual dispatch).
- **`DEPLOYMENT.md`** — documents setup, URL, and the `PAGES_BASE` knob.

## ⚠️ One-time manual step (required before the first deploy succeeds)
In the repo: **Settings → Pages → Build and deployment → Source = "GitHub Actions"**. Until then the `deploy-pages` job will fail. Once set, pushes to `main` publish to **https://davidleathers113.github.io/checkers/**.

## Verification
- Default build byte-identical to before (`/` paths, `/sw.js`).
- `PAGES_BASE=/checkers/` build emits `/checkers/*` assets + `/checkers/sw.js`; all URLs serve **200** under `vite preview`.
- Gate green: lint, typecheck, **jest 368**, both builds, **`test:e2e` 142**, **`test:e2e:visual` 20**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
