### PR TITLE
feat(jumpOwn): capture-then-hop

### DIFF
--- a/src/rules/JumpOwnRules.ts
+++ b/src/rules/JumpOwnRules.ts
@@ -42,17 +42,25 @@ interface JumpStep {
  * may stop after any jump.
  *
  * Opponent captures keep their normal behaviour: they remove the captured piece
- * and remain mandatory. Hops are only available when you are not already forced
- * to capture an opponent, so every generated jump sequence begins with a hop.
+ * and remain mandatory. Captures take priority over a *pure* hop or slide — when
+ * a capture is available your move must BEGIN with a capture (you cannot dodge a
+ * forced jump by hopping first) and must still take the maximum number of
+ * opponents — but once you have captured you may keep going with hops and/or
+ * further captures. So both orders are legal in a single turn: hop-then-capture
+ * (when no direct capture forces your hand) and capture-then-hop.
  */
 export class JumpOwnRules extends StandardRules {
   override getPossibleMoves(board: Board, position: Position): Move[] {
     const piece = board.getPiece(position);
     if (!piece) return [];
 
-    // Mandatory opponent captures take priority — no hops while forced to jump.
-    if (this.getMandatoryMoves(board, piece.player).length > 0) {
-      return super.getPossibleMoves(board, position);
+    const mandatory = this.getMandatoryMoves(board, piece.player);
+    if (mandatory.length > 0) {
+      // Forced to capture: only capture-initiated, maximum-capture sequences are
+      // legal (hops may extend them). A piece with no capture of its own offers
+      // nothing — another piece must take the jump.
+      if (piece.getCaptureMoves(position, board).length === 0) return [];
+      return this.forcedCaptureSequences(board, position, piece, mandatory[0]!.getCaptureCount());
     }
 
     // No forced capture: regular slides, plus every hop / hop-then-capture
@@ -60,6 +68,25 @@ export class JumpOwnRules extends StandardRules {
     const base = super.getPossibleMoves(board, position);
     const jumps = this.getJumpSequences(board, position, piece);
     return this.dedupeMoves([...base, ...jumps]);
+  }
+
+  override getAllPossibleMoves(board: Board, player: Player): Move[] {
+    const mandatory = this.getMandatoryMoves(board, player);
+    if (mandatory.length === 0) {
+      // Not forced: the inherited logic delegates to getPossibleMoves per piece
+      // (slides + hop sequences), which is exactly what we want.
+      return super.getAllPossibleMoves(board, player);
+    }
+
+    // Forced to capture: every capture-initiated, maximum-capture sequence
+    // (optionally extended with hops) from any piece that can start a capture.
+    const max = mandatory[0]!.getCaptureCount();
+    const moves: Move[] = [];
+    for (const { position, piece } of board.getPlayerPieces(player)) {
+      if (piece.getCaptureMoves(position, board).length === 0) continue;
+      moves.push(...this.forcedCaptureSequences(board, position, piece, max));
+    }
+    return this.dedupeMoves(moves);
   }
 
   override validateMove(board: Board, move: Move): boolean {
@@ -71,12 +98,26 @@ export class JumpOwnRules extends StandardRules {
     const piece = board.getPiece(move.from);
     if (!piece) return false;
 
-    // A hop (or hop-then-capture) is only legal when not forced to capture.
-    if (this.getMandatoryMoves(board, piece.player).length > 0) {
-      return false;
-    }
+    // Otherwise the move is only legal if it is one of the jump sequences this
+    // position offers (which already encode the mandatory/maximum-capture rules).
+    return this.getPossibleMoves(board, move.from).some(seq => seq.equals(move));
+  }
 
-    return this.getJumpSequences(board, move.from, piece).some(seq => seq.equals(move));
+  /**
+   * The legal jump sequences for `piece` when the player is forced to capture:
+   * those that begin with a capture and take exactly `maxCaptures` opponents
+   * (the player-wide maximum). Hops may be interleaved/appended freely, but they
+   * never change the capture count, so a forced turn always captures the max.
+   */
+  private forcedCaptureSequences(
+    board: Board,
+    position: Position,
+    piece: Piece,
+    maxCaptures: number
+  ): Move[] {
+    return this.getJumpSequences(board, position, piece).filter(
+      seq => seq.steps[0]?.captured !== undefined && seq.getCaptureCount() === maxCaptures
+    );
   }
 
   /**

--- a/tests/rules/JumpOwnRules.test.ts
+++ b/tests/rules/JumpOwnRules.test.ts
@@ -209,6 +209,68 @@ describe('JumpOwnRules — hop over your own man', () => {
     });
   });
 
+  describe('capture then hop', () => {
+    it('lets a piece capture an opponent and then hop its own man in one turn', () => {
+      const board = new Board(8)
+        .setPiece(new Position(5, 2), new RegularPiece(RED)) // mover; captures (4,3)
+        .setPiece(new Position(4, 3), new RegularPiece(BLACK)) // opponent
+        .setPiece(new Position(2, 5), new RegularPiece(RED)); // own man to hop after the capture
+
+      const moves = rules.getPossibleMoves(board, new Position(5, 2));
+
+      // The plain capture is still offered...
+      expect(hasMove(moves, new Position(5, 2), new Position(3, 4))).toBe(true);
+      // ...and so is capture-then-hop: capture (4,3)->(3,4), then hop (2,5)->(1,6).
+      const combo = moves.find(m => m.to.equals(new Position(1, 6)));
+      expect(combo).toBeDefined();
+      expect(combo!.captures.some(c => c.equals(new Position(4, 3)))).toBe(true);
+      expect(rules.validateMove(board, combo!)).toBe(true);
+
+      const after = combo!.apply(board);
+      expect(after.getPiece(new Position(1, 6))?.player).toBe(RED); // landed
+      expect(after.isEmpty(new Position(4, 3))).toBe(true); // opponent captured
+      expect(after.getPiece(new Position(2, 5))?.player).toBe(RED); // own man hopped, not removed
+      expect(after.isEmpty(new Position(5, 2))).toBe(true); // moved away
+    });
+
+    it('still requires the maximum capture (a shorter capture-then-hop is not offered)', () => {
+      const board = new Board(8)
+        .setPiece(new Position(6, 1), new RegularPiece(RED)) // can double-capture
+        .setPiece(new Position(5, 2), new RegularPiece(BLACK))
+        .setPiece(new Position(3, 4), new RegularPiece(BLACK))
+        .setPiece(new Position(3, 2), new RegularPiece(RED)); // tempting 1-capture-then-hop
+
+      const moves = rules.getPossibleMoves(board, new Position(6, 1));
+
+      // Only the maximum (two-capture) line is legal.
+      expect(moves.every(m => m.getCaptureCount() === 2)).toBe(true);
+      expect(hasMove(moves, new Position(6, 1), new Position(2, 5))).toBe(true);
+      // The shorter one-capture-then-hop landing (2,1) is suppressed.
+      expect(moves.find(m => m.to.equals(new Position(2, 1)))).toBeUndefined();
+    });
+
+    it('executes a capture-then-hop through the Game controller', () => {
+      class CaptureHopSetupRules extends JumpOwnRules {
+        override getInitialBoard(): Board {
+          return new Board(8)
+            .setPiece(new Position(5, 2), new RegularPiece(RED))
+            .setPiece(new Position(4, 3), new RegularPiece(BLACK))
+            .setPiece(new Position(2, 5), new RegularPiece(RED))
+            .setPiece(new Position(0, 7), new RegularPiece(BLACK)); // keeps the game live
+        }
+      }
+      const game = new Game({ ruleEngine: new CaptureHopSetupRules() });
+      const combo = game.getPossibleMoves(new Position(5, 2)).find(m => m.to.equals(new Position(1, 6)));
+      expect(combo).toBeDefined();
+
+      expect(game.makeMove(combo!)).toBe(true);
+      const board = game.getBoard();
+      expect(board.getPiece(new Position(1, 6))?.player).toBe(RED);
+      expect(board.isEmpty(new Position(4, 3))).toBe(true); // opponent removed
+      expect(board.getPiece(new Position(2, 5))?.player).toBe(RED); // own man survives
+    });
+  });
+
   describe('kings', () => {
     it('hops over an own piece flying-style and may land on any empty square beyond', () => {
       const board = new Board(8)


### PR DESCRIPTION
## Summary

Completes the Jump Your Own Man symmetry: you can now **capture an opponent and then hop your own man** in the same turn (the reverse — hop-then-capture — shipped in #12).

Previously, whenever a capture was forced the engine fell back to *pure* standard captures, so no hop could follow a jump.

## How it works
The unified jump search now runs in the forced-capture case too, constrained so the move must **begin with a capture** (you can't dodge a forced jump by hopping first) and must still take the **maximum** number of opponents — hops may be interleaved/appended but never change the capture count. `getPossibleMoves`, `validateMove`, and a new `getAllPossibleMoves` override all honour this, so the move hints, the AI, and validation agree.

## Tests
- Capture-then-hop is offered and applies correctly (own man survives, opponent removed).
- The maximum-capture rule still holds — a shorter capture-then-hop is suppressed when a longer pure capture exists.
- End-to-end via the Game controller.

## Verification
- `npm test` — **377/377** (+3 new tests); lint, typecheck, `build:web` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
