### PR TITLE
fix(rules): no backward man-captures; forced jumps allow hop-enabled captures

### DIFF
--- a/examples/InternationalDraughts.ts
+++ b/examples/InternationalDraughts.ts
@@ -1,18 +1,44 @@
 import { StandardRules } from '../src/rules/StandardRules';
 import { Board } from '../src/core/Board';
 import { Position } from '../src/core/Position';
-import { Player } from '../src/types';
+import { Player, Direction } from '../src/types';
 import { RegularPiece } from '../src/pieces/RegularPiece';
+
+/**
+ * An International Draughts man. Unlike a standard (American) man — which
+ * captures forward only — a draughts man may capture in any diagonal direction,
+ * so it overrides {@link getCaptureDirections}. It is otherwise a regular piece
+ * (it still *moves* forward only and promotes to a king on the far row).
+ */
+export class InternationalManPiece extends RegularPiece {
+  override getCaptureDirections(): Direction[] {
+    return [
+      Direction.NORTH_WEST,
+      Direction.NORTH_EAST,
+      Direction.SOUTH_WEST,
+      Direction.SOUTH_EAST,
+    ];
+  }
+
+  override canCaptureInDirection(): boolean {
+    return true;
+  }
+
+  // Preserve the type across board copies (Board.copy() calls piece.copy()).
+  override copy(): InternationalManPiece {
+    return new InternationalManPiece(this.player, this.id);
+  }
+}
 
 /**
  * International Draughts (10x10).
  *
- * The engine's core already provides the rules that distinguish International
- * Draughts from a naive game: flying kings (see {@link KingPiece}), captures in
- * any diagonal direction for men, multi-jump sequences, and the mandatory
- * maximum-capture rule (see {@link StandardRules.getMandatoryMoves}). So this
- * variant only needs the larger board and its four-rows-per-side setup; all
- * move generation and validation are inherited and stay consistent.
+ * The engine's core already provides flying kings (see {@link KingPiece}),
+ * multi-jump sequences, and the mandatory maximum-capture rule (see
+ * {@link StandardRules.getMandatoryMoves}). This variant adds the larger board,
+ * its four-rows-per-side setup, and men that capture in any direction (via
+ * {@link InternationalManPiece}); all other move generation and validation are
+ * inherited and stay consistent.
  */
 export class InternationalDraughtsRules extends StandardRules {
   constructor(boardSize: number = 10) {
@@ -30,7 +56,7 @@ export class InternationalDraughtsRules extends StandardRules {
       for (let col = 0; col < 10; col++) {
         const pos = new Position(row, col);
         if (pos.isDarkSquare()) {
-          board = board.setPiece(pos, new RegularPiece(Player.BLACK));
+          board = board.setPiece(pos, new InternationalManPiece(Player.BLACK));
         }
       }
     }
@@ -40,7 +66,7 @@ export class InternationalDraughtsRules extends StandardRules {
       for (let col = 0; col < 10; col++) {
         const pos = new Position(row, col);
         if (pos.isDarkSquare()) {
-          board = board.setPiece(pos, new RegularPiece(Player.RED));
+          board = board.setPiece(pos, new InternationalManPiece(Player.RED));
         }
       }
     }

--- a/src/pieces/Piece.ts
+++ b/src/pieces/Piece.ts
@@ -55,6 +55,16 @@ export abstract class Piece {
   abstract getMoveDirections(): Direction[];
 
   /**
+   * Gets the directions this piece may *capture* in. Defaults to its move
+   * directions — so regular men capture forward only (standard/American rules),
+   * while kings capture in every diagonal direction. Variants that let men
+   * capture backward (e.g. International Draughts) override this.
+   */
+  getCaptureDirections(): Direction[] {
+    return this.getMoveDirections();
+  }
+
+  /**
    * Checks if this piece can capture in a given direction.
    */
   abstract canCaptureInDirection(direction: Direction): boolean;

--- a/src/pieces/RegularPiece.ts
+++ b/src/pieces/RegularPiece.ts
@@ -78,8 +78,9 @@ export class RegularPiece extends Piece {
     capturedOnPath: Set<string>,
     allSequences: Move[]
   ): void {
-    // Check all four diagonal directions for the next jump.
-    for (const direction of [Direction.NORTH_WEST, Direction.NORTH_EAST, Direction.SOUTH_WEST, Direction.SOUTH_EAST]) {
+    // Check each capturable diagonal direction for the next jump. Regular men
+    // capture forward only (getCaptureDirections); International men override it.
+    for (const direction of this.getCaptureDirections()) {
       const opponentPos = this.getNextPosition(currentPos, direction, board.size);
       if (!opponentPos) continue;
 
@@ -159,10 +160,10 @@ export class RegularPiece extends Piece {
   }
 
   /**
-   * Regular pieces can capture in any direction.
+   * Regular pieces capture only in their (forward) capture directions.
    */
-  canCaptureInDirection(_direction: Direction): boolean {
-    return true;
+  canCaptureInDirection(direction: Direction): boolean {
+    return this.getCaptureDirections().includes(direction);
   }
 
   /**

--- a/src/rules/JumpOwnRules.ts
+++ b/src/rules/JumpOwnRules.ts
@@ -41,50 +41,47 @@ interface JumpStep {
  * to the next. Every prefix of such a sequence is a legal move, so the player
  * may stop after any jump.
  *
- * Opponent captures keep their normal behaviour: they remove the captured piece
- * and remain mandatory. Captures take priority over a *pure* hop or slide — when
- * a capture is available your move must BEGIN with a capture (you cannot dodge a
- * forced jump by hopping first) and must still take the maximum number of
- * opponents — but once you have captured you may keep going with hops and/or
- * further captures. So both orders are legal in a single turn: hop-then-capture
- * (when no direct capture forces your hand) and capture-then-hop.
+ * Opponent captures keep their normal behaviour: they remove the captured piece.
+ * When any direct jump is on the board the move must capture an opponent (you
+ * may not slide or make a *pure* hop instead) — but the capture may be reached
+ * by hopping your own men first, and you may hop after capturing. So a forced
+ * turn can be a direct capture, a hop-then-capture, a capture-then-hop, or any
+ * chain of these; whichever capturing sequence you like is allowed. Men capture
+ * forward only (see {@link Piece.getCaptureDirections}); kings capture in any
+ * diagonal direction.
  */
 export class JumpOwnRules extends StandardRules {
   override getPossibleMoves(board: Board, position: Position): Move[] {
     const piece = board.getPiece(position);
     if (!piece) return [];
 
-    const mandatory = this.getMandatoryMoves(board, piece.player);
-    if (mandatory.length > 0) {
-      // Forced to capture: only capture-initiated, maximum-capture sequences are
-      // legal (hops may extend them). A piece with no capture of its own offers
-      // nothing — another piece must take the jump.
-      if (piece.getCaptureMoves(position, board).length === 0) return [];
-      return this.forcedCaptureSequences(board, position, piece, mandatory[0]!.getCaptureCount());
+    if (this.getMandatoryMoves(board, piece.player).length > 0) {
+      // A jump is on the board, so the move must capture an opponent. Any
+      // sequence that captures is legal — including ones that reach the capture
+      // by hopping your own men first, or that hop after capturing. A piece that
+      // cannot reach a capture (even via hops) offers nothing.
+      return this.capturingSequences(board, position, piece);
     }
 
     // No forced capture: regular slides, plus every hop / hop-then-capture
-    // sequence reachable from here.
+    // sequence reachable from here (the hop-then-capture is optional here).
     const base = super.getPossibleMoves(board, position);
     const jumps = this.getJumpSequences(board, position, piece);
     return this.dedupeMoves([...base, ...jumps]);
   }
 
   override getAllPossibleMoves(board: Board, player: Player): Move[] {
-    const mandatory = this.getMandatoryMoves(board, player);
-    if (mandatory.length === 0) {
+    if (this.getMandatoryMoves(board, player).length === 0) {
       // Not forced: the inherited logic delegates to getPossibleMoves per piece
       // (slides + hop sequences), which is exactly what we want.
       return super.getAllPossibleMoves(board, player);
     }
 
-    // Forced to capture: every capture-initiated, maximum-capture sequence
-    // (optionally extended with hops) from any piece that can start a capture.
-    const max = mandatory[0]!.getCaptureCount();
+    // Forced to capture: every capturing sequence (direct, hop-then-capture, or
+    // capture-then-hop) from any piece that can reach a capture.
     const moves: Move[] = [];
     for (const { position, piece } of board.getPlayerPieces(player)) {
-      if (piece.getCaptureMoves(position, board).length === 0) continue;
-      moves.push(...this.forcedCaptureSequences(board, position, piece, max));
+      moves.push(...this.capturingSequences(board, position, piece));
     }
     return this.dedupeMoves(moves);
   }
@@ -99,25 +96,13 @@ export class JumpOwnRules extends StandardRules {
     if (!piece) return false;
 
     // Otherwise the move is only legal if it is one of the jump sequences this
-    // position offers (which already encode the mandatory/maximum-capture rules).
+    // position offers (which already encode the mandatory-capture rule).
     return this.getPossibleMoves(board, move.from).some(seq => seq.equals(move));
   }
 
-  /**
-   * The legal jump sequences for `piece` when the player is forced to capture:
-   * those that begin with a capture and take exactly `maxCaptures` opponents
-   * (the player-wide maximum). Hops may be interleaved/appended freely, but they
-   * never change the capture count, so a forced turn always captures the max.
-   */
-  private forcedCaptureSequences(
-    board: Board,
-    position: Position,
-    piece: Piece,
-    maxCaptures: number
-  ): Move[] {
-    return this.getJumpSequences(board, position, piece).filter(
-      seq => seq.steps[0]?.captured !== undefined && seq.getCaptureCount() === maxCaptures
-    );
+  /** Every jump sequence for `piece` that captures at least one opponent. */
+  private capturingSequences(board: Board, position: Position, piece: Piece): Move[] {
+    return this.getJumpSequences(board, position, piece).filter(seq => seq.getCaptureCount() > 0);
   }
 
   /**
@@ -130,9 +115,8 @@ export class JumpOwnRules extends StandardRules {
    * correctly. The search runs on a simulated board (the moving piece is
    * relocated and captured opponents removed at each step) so square occupancy
    * is always accurate; a `visited` set of landing squares prevents hop cycles.
-   *
-   * Callers only invoke this when the player is not under a mandatory capture,
-   * so every sequence necessarily begins with a hop.
+   * Callers filter the result by capture count to enforce the mandatory-jump
+   * rule (see {@link capturingSequences}).
    */
   private getJumpSequences(board: Board, position: Position, piece: Piece): Move[] {
     const results = new Map<string, Move>();
@@ -170,16 +154,18 @@ export class JumpOwnRules extends StandardRules {
 
   /**
    * The immediate jumps available from `from` on `board` for `piece`: captures
-   * over an opponent (any direction) and hops over an own piece (the piece's
-   * own move directions). Regular pieces jump a single adjacent square; kings
-   * glide over empty squares to the first piece and may land anywhere beyond it.
+   * over an opponent (in the piece's capture directions — forward only for a
+   * standard man) and hops over an own piece (the piece's own move directions).
+   * Regular pieces jump a single adjacent square; kings glide over empty squares
+   * to the first piece and may land anywhere beyond it.
    */
   private nextJumps(board: Board, from: Position, piece: Piece): JumpStep[] {
     const jumps: JumpStep[] = [];
 
     if (!piece.isKing()) {
-      // Captures: men may capture in any diagonal direction.
-      for (const direction of ALL_DIRECTIONS) {
+      // Captures: only in the man's capture directions (forward for a standard
+      // man; any direction for an International man).
+      for (const direction of piece.getCaptureDirections()) {
         const { dRow, dCol } = DELTAS[direction];
         const over = new Position(from.row + dRow, from.col + dCol);
         const landing = new Position(from.row + 2 * dRow, from.col + 2 * dCol);

--- a/src/strategies/DiagonalMoveValidator.ts
+++ b/src/strategies/DiagonalMoveValidator.ts
@@ -47,10 +47,18 @@ export class DiagonalMoveValidator extends BaseMoveValidator {
         );
       }
 
-      // Direction constraint applies to non-capture moves only; regular pieces
-      // may capture in any diagonal direction (see RegularPiece.getCaptureMoves).
-      if (!move.isCapture() && !this.isValidDirectionForRegularPiece(move, piece.player)) {
-        throw new InvalidMoveError(move, 'Regular pieces can only move forward');
+      if (!move.isCapture()) {
+        // Plain moves must go forward.
+        if (!this.isValidDirectionForRegularPiece(move, piece.player)) {
+          throw new InvalidMoveError(move, 'Regular pieces can only move forward');
+        }
+      } else {
+        // Captures must be in one of the piece's capture directions — forward
+        // only for a standard man, any direction for an International man.
+        const direction = move.getDirection();
+        if (!direction || !(piece.getCaptureDirections() as readonly string[]).includes(direction)) {
+          throw new InvalidMoveError(move, 'This piece cannot capture in that direction');
+        }
       }
     } else {
       // Kings can move any distance, but path must be clear (except for captures)

--- a/tests/performance/OptimizationBenchmark.test.ts
+++ b/tests/performance/OptimizationBenchmark.test.ts
@@ -54,19 +54,20 @@ describe('Optimization Benchmarks', () => {
       const board = new Board(8);
       
       // Set up a complex capture scenario
-      const redPiece = new RegularPiece(Player.RED);
+      // Black moves down the board, so a forward triple-jump runs (1,1) -> (7,7)
+      // capturing the RED men at (2,2), (4,4), (6,6).
       const blackPiece = new RegularPiece(Player.BLACK);
-      
+
       // Create a triple-jump scenario
       let testBoard = board
-        .setPiece(new Position(0, 0), redPiece)
         .setPiece(new Position(1, 1), blackPiece)
-        .setPiece(new Position(3, 3), blackPiece)
-        .setPiece(new Position(5, 5), blackPiece);
-      
+        .setPiece(new Position(2, 2), new RegularPiece(Player.RED))
+        .setPiece(new Position(4, 4), new RegularPiece(Player.RED))
+        .setPiece(new Position(6, 6), new RegularPiece(Player.RED));
+
       // Measure capture move generation
-      const captures = PerformanceProfiler.measure('capture-search', () => 
-        redPiece.getCaptureMoves(new Position(0, 0), testBoard)
+      const captures = PerformanceProfiler.measure('capture-search', () =>
+        blackPiece.getCaptureMoves(new Position(1, 1), testBoard)
       );
       
       const stats = PerformanceProfiler.getStats('capture-search');

--- a/tests/pieces/RegularPiece.test.ts
+++ b/tests/pieces/RegularPiece.test.ts
@@ -102,13 +102,13 @@ describe('RegularPiece', () => {
   describe('getCaptureMoves', () => {
     it('should return capture moves', () => {
       board = board.setPiece(new Position(3, 3), redPiece);
-      board = board.setPiece(new Position(4, 4), blackPiece); // Enemy to capture
-      
+      board = board.setPiece(new Position(2, 4), blackPiece); // Enemy forward (NE) of RED
+
       const captureMoves = redPiece.getCaptureMoves(new Position(3, 3), board);
-      
+
       expect(captureMoves).toHaveLength(1);
-      expect(captureMoves[0]!.to).toEqual(new Position(5, 5));
-      expect(captureMoves[0]!.captures).toContainEqual(new Position(4, 4));
+      expect(captureMoves[0]!.to).toEqual(new Position(1, 5));
+      expect(captureMoves[0]!.captures).toContainEqual(new Position(2, 4));
     });
 
     it('should return empty array when no captures available', () => {
@@ -180,9 +180,12 @@ describe('RegularPiece', () => {
   });
 
   describe('canCaptureInDirection', () => {
-    it('should allow captures in any direction', () => {
+    it('allows captures only in the forward directions (men cannot capture backward)', () => {
+      // RED moves toward row 0, so NW/NE are forward and SW/SE are backward.
       expect(redPiece.canCaptureInDirection(Direction.NORTH_WEST)).toBe(true);
-      expect(redPiece.canCaptureInDirection(Direction.SOUTH_EAST)).toBe(true);
+      expect(redPiece.canCaptureInDirection(Direction.NORTH_EAST)).toBe(true);
+      expect(redPiece.canCaptureInDirection(Direction.SOUTH_WEST)).toBe(false);
+      expect(redPiece.canCaptureInDirection(Direction.SOUTH_EAST)).toBe(false);
     });
   });
 

--- a/tests/rules/CustomRulesBase.test.ts
+++ b/tests/rules/CustomRulesBase.test.ts
@@ -59,7 +59,7 @@ describe('CustomRulesBase', () => {
     const helper = new HelperRules();
     const board = new Board(8)
       .setPiece(new Position(3, 3), new RegularPiece(Player.RED))
-      .setPiece(new Position(4, 4), new RegularPiece(Player.BLACK))
+      .setPiece(new Position(2, 4), new RegularPiece(Player.BLACK)) // forward (NE) capture for RED
       .setPiece(new Position(6, 6), new KingPiece(Player.RED));
 
     expect(helper.publicCaptures(board, Player.RED).length).toBeGreaterThan(0);

--- a/tests/rules/InternationalDraughts.test.ts
+++ b/tests/rules/InternationalDraughts.test.ts
@@ -1,0 +1,38 @@
+import { InternationalDraughtsRules, InternationalManPiece } from '../../examples/InternationalDraughts';
+import { Board } from '../../src/core/Board';
+import { Position } from '../../src/core/Position';
+import { RegularPiece } from '../../src/pieces/RegularPiece';
+import { Player } from '../../src/types';
+
+const RED = Player.RED;
+const BLACK = Player.BLACK;
+
+describe('International Draughts — men capture in any direction', () => {
+  it('lets an International man capture backward (unlike a standard man)', () => {
+    // BLACK sits behind RED at (4,4) — SE, which is backward for RED.
+    const board = new Board(8)
+      .setPiece(new Position(3, 3), new InternationalManPiece(RED))
+      .setPiece(new Position(4, 4), new RegularPiece(BLACK));
+
+    const caps = new InternationalManPiece(RED).getCaptureMoves(new Position(3, 3), board);
+    expect(caps.length).toBeGreaterThan(0);
+    expect(caps[0]!.to).toEqual(new Position(5, 5)); // landed beyond the backward capture
+
+    // A standard man in the same position cannot capture backward.
+    const standard = new RegularPiece(RED).getCaptureMoves(new Position(3, 3), board);
+    expect(standard).toHaveLength(0);
+  });
+
+  it('preserves the man type across a copy (so backward captures survive a move)', () => {
+    const man = new InternationalManPiece(RED);
+    expect(man.copy()).toBeInstanceOf(InternationalManPiece);
+  });
+
+  it('sets up a 10x10 board of International men', () => {
+    const board = new InternationalDraughtsRules().getInitialBoard();
+    expect(board.size).toBe(10);
+    expect(board.getPiece(new Position(0, 1))).toBeInstanceOf(InternationalManPiece);
+    expect(board.getPieceCount(RED)).toBe(20);
+    expect(board.getPieceCount(BLACK)).toBe(20);
+  });
+});

--- a/tests/rules/JumpOwnRules.test.ts
+++ b/tests/rules/JumpOwnRules.test.ts
@@ -159,16 +159,48 @@ describe('JumpOwnRules — hop over your own man', () => {
       expect(after.isEmpty(new Position(1, 4))).toBe(true);
     });
 
-    it('does not offer a hop-then-capture while a direct capture is mandatory', () => {
+    it('offers nothing for a piece that cannot reach any capture while a jump is mandatory', () => {
       const board = new Board(8)
         .setPiece(new Position(6, 1), new RegularPiece(RED))
-        .setPiece(new Position(5, 2), new RegularPiece(RED)) // would enable a hop
+        .setPiece(new Position(5, 2), new RegularPiece(RED)) // (6,1) could hop this, but...
         .setPiece(new Position(5, 6), new RegularPiece(RED))
         .setPiece(new Position(4, 5), new RegularPiece(BLACK)); // (5,6)x(4,5)->(3,4) is forced
+      // (6,1) can only make a pure hop, which reaches no capture — so while a
+      // jump is mandatory it offers nothing (a pure hop/slide is not allowed).
       const moves = rules.getPossibleMoves(board, new Position(6, 1));
-      // No hop and no hop-then-capture while forced to take the mandatory jump.
-      expect(hasMove(moves, new Position(6, 1), new Position(4, 3))).toBe(false);
-      expect(moves.find(m => m.to.equals(new Position(2, 5)))).toBeUndefined();
+      expect(moves).toHaveLength(0);
+    });
+
+    it('lets a different piece satisfy a forced jump by hopping its own man first', () => {
+      // (5,0) has a direct capture, so a jump is mandatory. (6,3) has no direct
+      // capture, but can hop its own man at (5,4) to (4,5) and then jump the
+      // BLACK at (3,6). That hop-then-capture must be offered (not locked out).
+      const board = new Board(8)
+        .setPiece(new Position(5, 0), new RegularPiece(RED)) // forces the jump (x(4,1)->(3,2))
+        .setPiece(new Position(4, 1), new RegularPiece(BLACK))
+        .setPiece(new Position(6, 3), new RegularPiece(RED)) // reaches a capture via a hop
+        .setPiece(new Position(5, 4), new RegularPiece(RED)) // own man to hop over (NE)
+        .setPiece(new Position(3, 6), new RegularPiece(BLACK)); // captured after the hop
+
+      const moves = rules.getPossibleMoves(board, new Position(6, 3));
+      const combo = moves.find(m => m.to.equals(new Position(2, 7)));
+      expect(combo).toBeDefined();
+      expect(combo!.captures.some(c => c.equals(new Position(3, 6)))).toBe(true);
+      expect(rules.validateMove(board, combo!)).toBe(true);
+    });
+
+    it('does not let a regular man capture backward (only kings may)', () => {
+      // BLACK sits behind RED (SE = backward for RED). No capture should exist.
+      const board = new Board(8)
+        .setPiece(new Position(3, 3), new RegularPiece(RED))
+        .setPiece(new Position(4, 4), new RegularPiece(BLACK))
+        .setPiece(new Position(2, 7), new RegularPiece(BLACK)); // keeps the game live
+      const moves = rules.getPossibleMoves(board, new Position(3, 3));
+      expect(moves.some(m => m.isCapture())).toBe(false);
+      // A king in the same spot may capture backward.
+      const kingBoard = board.setPiece(new Position(3, 3), new KingPiece(RED));
+      const kingMoves = rules.getPossibleMoves(kingBoard, new Position(3, 3));
+      expect(kingMoves.some(m => m.isCapture() && m.captures.some(c => c.equals(new Position(4, 4))))).toBe(true);
     });
 
     it('lets a king hop its own man flying-style and then capture an opponent', () => {
@@ -233,20 +265,21 @@ describe('JumpOwnRules — hop over your own man', () => {
       expect(after.isEmpty(new Position(5, 2))).toBe(true); // moved away
     });
 
-    it('still requires the maximum capture (a shorter capture-then-hop is not offered)', () => {
+    it('offers shorter capturing lines too (no forced maximum in this variant)', () => {
       const board = new Board(8)
         .setPiece(new Position(6, 1), new RegularPiece(RED)) // can double-capture
         .setPiece(new Position(5, 2), new RegularPiece(BLACK))
         .setPiece(new Position(3, 4), new RegularPiece(BLACK))
-        .setPiece(new Position(3, 2), new RegularPiece(RED)); // tempting 1-capture-then-hop
+        .setPiece(new Position(3, 2), new RegularPiece(RED)); // enables a 1-capture-then-hop
 
       const moves = rules.getPossibleMoves(board, new Position(6, 1));
 
-      // Only the maximum (two-capture) line is legal.
-      expect(moves.every(m => m.getCaptureCount() === 2)).toBe(true);
+      // The full two-capture line is available...
       expect(hasMove(moves, new Position(6, 1), new Position(2, 5))).toBe(true);
-      // The shorter one-capture-then-hop landing (2,1) is suppressed.
-      expect(moves.find(m => m.to.equals(new Position(2, 1)))).toBeUndefined();
+      // ...and so is the shorter one-capture-then-hop (you are not forced to take the max).
+      expect(hasMove(moves, new Position(6, 1), new Position(2, 1))).toBe(true);
+      // Every offered move still captures at least one opponent.
+      expect(moves.every(m => m.getCaptureCount() >= 1)).toBe(true);
     });
 
     it('executes a capture-then-hop through the Game controller', () => {

--- a/tests/rules/StandardRules.test.ts
+++ b/tests/rules/StandardRules.test.ts
@@ -37,9 +37,9 @@ describe('StandardRules', () => {
       const blackPiece = new RegularPiece(Player.BLACK);
       
       board = board.setPiece(new Position(3, 3), redPiece);
-      board = board.setPiece(new Position(4, 4), blackPiece);
-      
-      const move = new Move(new Position(3, 3), new Position(5, 5), [new Position(4, 4)]);
+      board = board.setPiece(new Position(2, 4), blackPiece); // forward (NE) of RED
+
+      const move = new Move(new Position(3, 3), new Position(1, 5), [new Position(2, 4)]);
       expect(rules.validateMove(board, move)).toBe(true);
     });
 
@@ -48,8 +48,8 @@ describe('StandardRules', () => {
       const blackPiece = new RegularPiece(Player.BLACK);
       
       board = board.setPiece(new Position(3, 3), redPiece);
-      board = board.setPiece(new Position(4, 4), blackPiece);
-      
+      board = board.setPiece(new Position(2, 4), blackPiece); // forward capture available
+
       // When capture is available, regular moves should be invalid
       const regularMove = new Move(new Position(3, 3), new Position(2, 2));
       expect(rules.validateMove(board, regularMove)).toBe(false);
@@ -103,10 +103,10 @@ describe('StandardRules', () => {
       const blackPiece = new RegularPiece(Player.BLACK);
       
       board = board.setPiece(new Position(3, 3), redPiece);
-      board = board.setPiece(new Position(4, 4), blackPiece);
-      
+      board = board.setPiece(new Position(2, 4), blackPiece); // forward capture available
+
       const moves = rules.getAllPossibleMoves(board, Player.RED);
-      
+
       // Should only return capture moves
       expect(moves.every(move => move.isCapture())).toBe(true);
     });
@@ -164,10 +164,10 @@ describe('StandardRules', () => {
       const blackPiece = new RegularPiece(Player.BLACK);
       
       board = board.setPiece(new Position(3, 3), redPiece);
-      board = board.setPiece(new Position(4, 4), blackPiece);
-      
+      board = board.setPiece(new Position(2, 4), blackPiece); // forward capture available
+
       const mandatory = rules.getMandatoryMoves(board, Player.RED);
-      
+
       expect(mandatory.length).toBeGreaterThan(0);
       expect(mandatory.every(move => move.isCapture())).toBe(true);
     });

--- a/tests/strategies/Validators.test.ts
+++ b/tests/strategies/Validators.test.ts
@@ -68,12 +68,20 @@ describe('DiagonalMoveValidator', () => {
     expect(() => v.validateMove(board, new Move(new Position(5, 2), new Position(6, 3)), RED)).toThrow(); // backward
   });
 
-  it('allows a regular backward capture (direction constraint is non-capture only)', () => {
-    const board = new Board(8)
+  it('rejects a backward capture for a regular man but allows a forward one', () => {
+    // SE is backward for RED — a man may not capture that way.
+    const backward = new Board(8)
       .setPiece(new Position(3, 3), new RegularPiece(RED))
       .setPiece(new Position(4, 4), new RegularPiece(BLACK));
-    const move = new Move(new Position(3, 3), new Position(5, 5), [new Position(4, 4)]); // SE = backward for RED
-    expect(v.validateMove(board, move, RED)).toBe(true);
+    const backwardMove = new Move(new Position(3, 3), new Position(5, 5), [new Position(4, 4)]);
+    expect(() => v.validateMove(backward, backwardMove, RED)).toThrow();
+
+    // NE is forward for RED — that capture is allowed.
+    const forward = new Board(8)
+      .setPiece(new Position(3, 3), new RegularPiece(RED))
+      .setPiece(new Position(2, 4), new RegularPiece(BLACK));
+    const forwardMove = new Move(new Position(3, 3), new Position(1, 5), [new Position(2, 4)]);
+    expect(v.validateMove(forward, forwardMove, RED)).toBe(true);
   });
 
   it('handles king path: clear passes, blocked throws', () => {
@@ -191,14 +199,14 @@ describe('MandatoryCaptureValidator', () => {
   it('rejects a non-capture when a capture exists', () => {
     const board = new Board(8)
       .setPiece(new Position(3, 3), new RegularPiece(RED))
-      .setPiece(new Position(4, 4), new RegularPiece(BLACK));
+      .setPiece(new Position(2, 4), new RegularPiece(BLACK)); // forward capture available
     expect(() => v.validateMove(board, new Move(new Position(3, 3), new Position(2, 2)), RED)).toThrow();
   });
 
   it('rejects a capture that is not among the available ones', () => {
     const board = new Board(8)
       .setPiece(new Position(3, 3), new RegularPiece(RED))
-      .setPiece(new Position(4, 4), new RegularPiece(BLACK));
+      .setPiece(new Position(2, 4), new RegularPiece(BLACK)); // forward capture available
     const bogus = new Move(new Position(3, 3), new Position(1, 1), [new Position(2, 2)]);
     expect(() => v.validateMove(board, bogus, RED)).toThrow();
   });


### PR DESCRIPTION
## Two rule bugs (reported from a live Jump Your Own Man game)

### 1. Men could capture backward
A regular (un-kinged) man was being offered backward jumps. Men should capture **forward only**; only kings capture in any direction. Capture direction was hard-coded to all four diagonals in both `RegularPiece` and `DiagonalMoveValidator`.

- New `Piece.getCaptureDirections()` defaults to the piece's move directions — forward for a man, every diagonal for a king. The capture search and validator now use it.
- International Draughts genuinely needs backward man-captures, so it gets an `InternationalManPiece` (overrides the capture directions and preserves its type across board copies). **International is unaffected.**

### 2. "You must jump!" locked out hop-enabled captures
When a direct jump existed, the board locked to *only* directly-jumping pieces — so a piece that could reach a capture by hopping its own man first (or hop after capturing) was unusable. Now, when a jump is mandatory, **any** sequence that captures at least one opponent is legal (direct, hop-then-capture, capture-then-hop, or any chain), from any piece that can reach a capture. This variant no longer forces the maximum capture — you may take any capturing line.

## Tests
- Men can't capture backward, but kings can; International men still can.
- A forced jump is satisfiable by hopping your own man first, then capturing.
- Shorter capturing lines are offered (no forced maximum).
- Existing standard-rules capture tests updated from backward to forward setups.

## Verification
- `npm test` — **382/382** (36 suites); lint, typecheck, `build:web` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
